### PR TITLE
Validate Journey Steps

### DIFF
--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -361,6 +361,7 @@ export interface JourneyStepType<T = any, E = any> {
     hasDataKey?: boolean
     hideTopHandle?: boolean
     hideBottomHandle?: boolean
+    validate?: (data: T) => boolean
 }
 
 export interface JourneyUserStep {

--- a/apps/ui/src/views/journey/JourneyEditor.css
+++ b/apps/ui/src/views/journey/JourneyEditor.css
@@ -92,21 +92,25 @@
     color: var(--color-red-hard);
 }
 
-.component.entrance .component-handle svg, .journey-step.entrance .step-header-icon svg {
+.component.entrance .component-handle svg,
+.journey-step.entrance .step-header-icon svg {
     margin-left: -4px;
 }
 
-.component.delay .component-handle, .journey-step.delay .step-header-icon {
+.component.delay .component-handle,
+.journey-step.delay .step-header-icon {
     background-color: var(--color-yellow-soft);
     color: var(--color-yellow-hard);
 }
 
-.component.action .component-handle, .journey-step.action .step-header-icon {
+.component.action .component-handle,
+.journey-step.action .step-header-icon {
     background-color: var(--color-blue-soft);
     color: var(--color-blue-hard);
 }
 
-.component.flow .component-handle, .journey-step.flow .step-header-icon {
+.component.flow .component-handle,
+.journey-step.flow .step-header-icon {
     background-color: var(--color-green-soft);
     color: var(--color-green-hard);
 }
@@ -195,6 +199,10 @@
     box-shadow: 0px 4px 30px rgba(22, 33, 74, 0.05);
     border-radius: 8px;
     min-width: 200px;
+}
+
+.journey-step.error {
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
 }
 
 .editing .journey-step {
@@ -331,7 +339,7 @@
 
 .journey-step-header .step-header-stats:hover .stat {
     color: var(--color-grey-hard);
-    
+
 }
 
 .journey-step-header .step-header-stats .stat {

--- a/apps/ui/src/views/journey/JourneyEditor.tsx
+++ b/apps/ui/src/views/journey/JourneyEditor.tsx
@@ -109,6 +109,8 @@ function JourneyStepNode({
         )
     }
 
+    const isValid = type.validate ? type.validate(data) : true
+
     return (
         <>
             {
@@ -122,6 +124,7 @@ function JourneyStepNode({
                     type.category,
                     selected && 'selected',
                     Array.isArray(type.sources) && 'journey-step-labelled-sources',
+                    isValid ? '' : 'error',
                     editing && 'editing',
                 )}
             >
@@ -163,7 +166,7 @@ function JourneyStepNode({
                             project,
                             journey,
                             value: data,
-                            onChange: () => {},
+                            onChange: () => { },
                         })
                     }
                     {

--- a/apps/ui/src/views/journey/steps/Action.tsx
+++ b/apps/ui/src/views/journey/steps/Action.tsx
@@ -81,7 +81,7 @@ export const actionStep: JourneyStepType<ActionConfig> = {
                     {campaign?.name ?? <>&#8211;</>}
                 </div>
                 <div className="journey-step-action-preview">
-                    { campaign && template
+                    {campaign && template
                         ? <Preview template={template} size="small" />
                         : (
                             <div className="journey-step-action-preview-placeholder">{t('journey_campaign_create_preview')}</div>
@@ -125,11 +125,14 @@ export const actionStep: JourneyStepType<ActionConfig> = {
                     )}
                 />
 
-                {campaign && <TemplateContextProvider campaign={campaign} setCampaign={() => {}}>
+                {campaign && <TemplateContextProvider campaign={campaign} setCampaign={() => { }}>
                     <JourneyTemplatePreview campaign={campaign} />
                 </TemplateContextProvider>}
             </>
         )
+    },
+    validate: ({ campaign_id }) => {
+        return !!campaign_id
     },
     hasDataKey: true,
 }

--- a/apps/ui/src/views/journey/steps/Entrance.tsx
+++ b/apps/ui/src/views/journey/steps/Entrance.tsx
@@ -111,7 +111,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                     } else {
                         s = 'once'
                     }
-                } catch {}
+                } catch { }
             }
             return (
                 <div style={{ maxWidth: 300 }}>
@@ -264,6 +264,15 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                 }
             </>
         )
+    },
+    validate: ({ trigger, event_name, list_id, schedule }) => {
+        if (trigger === 'event') {
+            return !!event_name
+        }
+        if (trigger === 'schedule') {
+            return !!list_id && !!schedule
+        }
+        return true
     },
     hasDataKey: true,
     hideTopHandle: true,

--- a/apps/ui/src/views/journey/steps/Exit.tsx
+++ b/apps/ui/src/views/journey/steps/Exit.tsx
@@ -47,6 +47,7 @@ export const exitStep: JourneyStepType<ExitConfig> = {
             .map((node) => ({ id: node.id, label: entranceName(node) }))
         return (
             <SingleSelect
+                required
                 options={steps}
                 label={t('exit_entrance_label')}
                 subtitle={t('exit_entrance_desc')}
@@ -55,6 +56,9 @@ export const exitStep: JourneyStepType<ExitConfig> = {
                 toValue={x => x.id}
             />
         )
+    },
+    validate: ({ entrance_uuid }) => {
+        return !!entrance_uuid
     },
     hideBottomHandle: true,
 }

--- a/apps/ui/src/views/journey/steps/JourneyLink.tsx
+++ b/apps/ui/src/views/journey/steps/JourneyLink.tsx
@@ -77,4 +77,7 @@ export const journeyLinkStep: JourneyStepType<JourneyLinkConfig> = {
             onChange={delay => onChange({ ...value, delay }) } />
         </>
     },
+    validate: ({ target_id, delay }) => {
+        return !!target_id && !!delay
+    },
 }


### PR DESCRIPTION
I often forget to set all the required values within journey steps, I’m trying to fix this by visually indicating when a step is misconfigured in the Journey Flow.

This PR includes validate functions for various journey steps to ensure all required properties are set. A red glow is shown around the step to indicate it’s missing a configuration value.

<img width="906" height="1178" alt="image" src="https://github.com/user-attachments/assets/f6a2bf43-bcee-49a6-ab79-ec30a1157bfe" />
