### PR TITLE
Fix entrance detail user display name

### DIFF
--- a/apps/ui/src/views/journey/EntranceDetails.tsx
+++ b/apps/ui/src/views/journey/EntranceDetails.tsx
@@ -27,10 +27,11 @@ export default function EntranceDetails() {
 
     const entrance = userSteps[0]
     const error = userSteps.find(s => s.type === 'error')
+    const displayName = user.full_name ?? user.email ?? user.phone ?? user.id
 
     return (
         <PageContent
-            title={`${user.full_name} - ${journey.name}`}
+            title={`${displayName} - ${journey.name}`}
             desc={
                 <>
                     <Tag variant={error ? 'error' : entrance.ended_at ? 'success' : 'info'}>


### PR DESCRIPTION
This PR fixes the name shown within the entrance details page. The entrance details page right now shows null as the user name when the user's full_name is not set.

<img width="2510" height="618" alt="image" src="https://github.com/user-attachments/assets/b13d0eb7-8df5-4b13-a1c2-e85ab052740d" />

---

<img width="2512" height="678" alt="image" src="https://github.com/user-attachments/assets/37a105f6-1a50-4386-b4a4-a53e487fde40" />
