### PR TITLE
Ensure webhook url is correct

### DIFF
--- a/services/platform/src/providers/email/MailgunEmailProvider.ts
+++ b/services/platform/src/providers/email/MailgunEmailProvider.ts
@@ -62,7 +62,7 @@ export default class MailgunEmailProvider extends EmailProvider {
     loadSetup(app: App): ProviderSetupMeta[] {
         return [{
             name: 'Webhook URL',
-            value: `${app.env.apiBaseUrl}/providers/${this.id}/${(this.constructor as any).namespace}`,
+            value: new URL(`/providers/${this.id}/${(this.constructor as any).namespace}`, app.env.apiBaseUrl).toString(),
         }]
     }
 

--- a/services/platform/src/providers/email/SESEmailProvider.ts
+++ b/services/platform/src/providers/email/SESEmailProvider.ts
@@ -64,7 +64,7 @@ export default class SESEmailProvider extends EmailProvider {
     loadSetup(app: App): ProviderSetupMeta[] {
         return [{
             name: 'Feedback URL',
-            value: `${app.env.apiBaseUrl}/providers/${this.id}/${(this.constructor as any).namespace}`,
+            value: new URL(`/providers/${this.id}/${(this.constructor as any).namespace}`, app.env.apiBaseUrl).toString(),
         }]
     }
 

--- a/services/platform/src/providers/email/SendGridEmailProvider.ts
+++ b/services/platform/src/providers/email/SendGridEmailProvider.ts
@@ -51,7 +51,7 @@ export default class SendGridEmailProvider extends EmailProvider {
     loadSetup(app: App): ProviderSetupMeta[] {
         return [{
             name: 'Webhook URL',
-            value: `${app.env.apiBaseUrl}/providers/${this.id}/${(this.constructor as any).namespace}`,
+            value: new URL(`/providers/${this.id}/${(this.constructor as any).namespace}`, app.env.apiBaseUrl).toString(),
         }]
     }
 


### PR DESCRIPTION
This PR ensures that webhooks are correct when the base url is containing a trailing `/`.