### PR TITLE
fix: update default mode in PreferencesContext to 'light' and comment…

### DIFF
--- a/services/console/src/ui/PreferencesContext.tsx
+++ b/services/console/src/ui/PreferencesContext.tsx
@@ -11,7 +11,8 @@ const language = () => {
 }
 
 const initial: Preferences = {
-    mode: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+    // mode: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+    mode: 'light',
     lang: language(),
     ...localStorageGetJson<Preferences>(PREFERENCES) ?? {},
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,


### PR DESCRIPTION
This pull request makes a small change to the user preferences initialization logic by setting the default theme mode explicitly to `'light'` instead of detecting the user's system preference.… out dynamic mode detection

Closes: #114 