### PR TITLE
Fix: added translation for "locale_field_subtitle"

### DIFF
--- a/services/console/public/locales/en.json
+++ b/services/console/public/locales/en.json
@@ -424,6 +424,7 @@
   "lists": "Lists",
   "live": "Live",
   "load_user": "Load User",
+  "locale_field_subtitle": "The abbreviated language code, e.g., en, es, fr.",
   "locales": "Locales",
   "login_basic_instructions": "Enter your email and password to continue.",
   "login_callback_error": "Authentication failed. Please try again.",


### PR DESCRIPTION
This pull request introduces a minor improvement to the English locale file by adding a helpful subtitle for the locale field.

- User Interface Enhancements:
  * Added a new string, `locale_field_subtitle`, to provide an example of an abbreviated language code (e.g., en, es, fr) in the `en.json` locale file.
  
 Closes: #117 