### PR TITLE
Include TinyGo in build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+FROM tinygo/tinygo:0.40.1 AS modules
+WORKDIR /src
+
+COPY Makefile ./
+COPY modules/ ./modules/
+COPY pkg/ ./pkg/
+
+RUN mkdir -p internal/providers/modules && make modules
+
 FROM node:24-alpine AS console
 ARG VITE_CLERK_PUBLISHABLE_KEY
 
@@ -17,6 +26,7 @@ RUN apk add --no-cache git ca-certificates make bash
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=modules /src/internal/providers/modules/*.wasm ./internal/providers/modules/
 COPY --from=console /src/console/dist ./internal/http/console/dist/
 RUN VERSION=${VERSION} SHORT_COMMIT=${COMMIT} make lunogram
 


### PR DESCRIPTION
This PR includes TinyGo in the build steps simplifying the docker-compose set-up.