### PR TITLE
fix(management): getCampaign returns Campaign directly, not wrapped

### DIFF
--- a/console/src/oapi/management.generated.ts
+++ b/console/src/oapi/management.generated.ts
@@ -5331,9 +5331,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        data: components["schemas"]["Campaign"];
-                    };
+                    "application/json": components["schemas"]["Campaign"];
                 };
             };
             default: components["responses"]["Error"];

--- a/internal/http/controllers/v1/management/oapi/resources.yml
+++ b/internal/http/controllers/v1/management/oapi/resources.yml
@@ -163,12 +163,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                properties:
-                  data:
-                    $ref: "#/components/schemas/Campaign"
+                $ref: "#/components/schemas/Campaign"
         default:
           $ref: "#/components/responses/Error"
 

--- a/internal/http/controllers/v1/management/oapi/resources_gen.go
+++ b/internal/http/controllers/v1/management/oapi/resources_gen.go
@@ -17298,10 +17298,8 @@ func (r DeleteCampaignResponse) ContentType() string {
 type GetCampaignResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *struct {
-		Data Campaign `json:"data"`
-	}
-	JSONDefault *Error
+	JSON200      *Campaign
+	JSONDefault  *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -24657,9 +24655,7 @@ func ParseGetCampaignResponse(rsp *http.Response) (*GetCampaignResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			Data Campaign `json:"data"`
-		}
+		var dest Campaign
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Corrects an OpenAPI spec inaccuracy: `getCampaign` was declared to return `{ data: Campaign }`, but the handler returns the `Campaign` directly.

```go
// internal/http/controllers/v1/management/campaigns.go (GetCampaign)
json.Write(w, http.StatusOK, campaign.OAPI())   // direct, not wrapped
```

Every other single-resource GET (`getJourney`, `getProject`, `getUser`, `getList`) already returns its schema directly — `getCampaign`'s `data` wrapper was the lone outlier, so the generated clients described a response shape the backend never sends.

## Changes

- `resources.yml`: `getCampaign` 200 response → `$ref: Campaign` (direct).
- Regenerated `resources_gen.go` (Go) and `management.generated.ts` (TS) with the pinned `oapi-codegen` v2.7.0 + `openapi-typescript`.

## Verification

- `go build ./...` and `go vet ./internal/http/controllers/v1/management/...`: clean.
- `tsc --noEmit` in `console`: 0 errors.
- No Go code consumed the old `GetCampaignResponse.JSON200.Data` shape.

Follow-up to the console OpenAPI migration (#241), which currently reads this response per the backend behaviour with a documented cast; that cast can be removed once this lands.
