### PR TITLE
feat(auth): normalized auth_methods schema + RBAC foundation

### DIFF
--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -306,11 +306,9 @@ const api = {
             await client.post(`${projectUrl(projectId)}/data/paths/sync`).then((r) => r.data),
     },
 
-    apiKeys: createProjectEntityPath<
-        ProjectApiKey,
-        ProjectApiKeyParams,
-        Omit<ProjectApiKeyParams, "scope">
-    >("keys"),
+    apiKeys: createProjectEntityPath<ProjectApiKey, ProjectApiKeyParams, ProjectApiKeyParams>(
+        "keys",
+    ),
 
     actions: createProjectEntityPath<Action, ActionCreateParams, ActionUpdateParams>("actions"),
 

--- a/console/src/oapi/management.generated.ts
+++ b/console/src/oapi/management.generated.ts
@@ -1909,7 +1909,7 @@ export interface paths {
         head?: never;
         /**
          * Update API key
-         * @description Updates an API key's name or description (scope cannot be changed)
+         * @description Updates an API key's name, role, or description
          */
         patch: operations["updateApiKey"];
         trace?: never;
@@ -4409,12 +4409,6 @@ export interface components {
         ProjectAdminList: components["schemas"]["PaginatedResponse"] & {
             results: components["schemas"]["ProjectAdmin"][];
         };
-        /**
-         * @description API key scope - public keys are safe to expose in client-side code
-         * @example secret
-         * @enum {string}
-         */
-        ApiKeyScope: "public" | "secret";
         ApiKey: {
             /**
              * Format: uuid
@@ -4433,7 +4427,6 @@ export interface components {
              * @example a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
              */
             value: string;
-            scope: components["schemas"]["ApiKeyScope"];
             role: components["schemas"]["ProjectRole"];
             /** @example API key for production environment */
             description?: string;
@@ -4451,7 +4444,6 @@ export interface components {
         CreateApiKey: {
             /** @example Production API Key */
             name: string;
-            scope: components["schemas"]["ApiKeyScope"];
             role?: components["schemas"]["ProjectRole"];
             /** @example API key for production environment */
             description?: string;

--- a/console/src/types.ts
+++ b/console/src/types.ts
@@ -377,12 +377,11 @@ export interface ProjectApiKey {
     id: UUID
     value: string
     name: string
-    scope: "public" | "secret"
     role?: ProjectRole
     description?: string
 }
 
-export type ProjectApiKeyParams = Pick<ProjectApiKey, "name" | "description" | "scope" | "role">
+export type ProjectApiKeyParams = Pick<ProjectApiKey, "name" | "description" | "role">
 
 export interface ExternalIDResponse {
     id: UUID

--- a/console/src/views/settings/ApiKeyDialog.tsx
+++ b/console/src/views/settings/ApiKeyDialog.tsx
@@ -39,11 +39,11 @@ const roleConfig: Record<
     },
     client: {
         icon: Smartphone,
-        description: "Write-only access for client-side SDKs and integrations.",
+        description: "Write-only access for ingesting events and user data.",
         permissions: [
             "Create & update users, events, and organizations",
             "No read access to any resource",
-            "Designed for client-side SDKs and public integrations",
+            "Designed for server-side ingestion integrations",
         ],
     },
     editor: {

--- a/console/src/views/settings/ApiKeys.tsx
+++ b/console/src/views/settings/ApiKeys.tsx
@@ -251,7 +251,6 @@ export default function ProjectApiKeys() {
                             await api.apiKeys.create(project.id, {
                                 name: name as string,
                                 description,
-                                scope: "secret",
                                 role,
                             })
                         }

--- a/internal/http/controllers/v1/management/apikeys.go
+++ b/internal/http/controllers/v1/management/apikeys.go
@@ -57,7 +57,7 @@ func (srv *ApiKeysController) CreateApiKey(w http.ResponseWriter, r *http.Reques
 		role = string(*body.Role)
 	}
 
-	apiKey, err := srv.store.ApiKeysStore.CreateApiKey(ctx, projectID, body.Name, string(body.Scope), role, body.Description)
+	apiKey, err := srv.store.ApiKeysStore.CreateApiKey(ctx, projectID, body.Name, role, body.Description)
 	if err != nil {
 		logger.Error("failed to create API key", zap.Error(err))
 		oapi.WriteProblem(w, err)

--- a/internal/http/controllers/v1/management/apikeys_test.go
+++ b/internal/http/controllers/v1/management/apikeys_test.go
@@ -58,31 +58,27 @@ func TestCreateApiKey(t *testing.T) {
 	tests := map[string]test{
 		"simple with default role": {
 			body: oapi.CreateApiKeyJSONRequestBody{
-				Name:  "Test API Key",
-				Scope: oapi.Secret,
+				Name: "Test API Key",
 			},
 			code: 201,
 		},
 		"with support role": {
 			body: oapi.CreateApiKeyJSONRequestBody{
-				Name:  "Support API Key",
-				Scope: oapi.Secret,
-				Role:  &roleSupport,
+				Name: "Support API Key",
+				Role: &roleSupport,
 			},
 			code: 201,
 		},
 		"with admin role": {
 			body: oapi.CreateApiKeyJSONRequestBody{
-				Name:  "Admin API Key",
-				Scope: oapi.Secret,
-				Role:  &roleAdmin,
+				Name: "Admin API Key",
+				Role: &roleAdmin,
 			},
 			code: 201,
 		},
 		"with description": {
 			body: oapi.CreateApiKeyJSONRequestBody{
 				Name:        "Described API Key",
-				Scope:       oapi.Secret,
 				Description: ptr.To("This is a test API key"),
 			},
 			code: 201,
@@ -136,7 +132,7 @@ func TestListApiKeys(t *testing.T) {
 	apiKeysStore := management.NewApiKeysStore(mgmt)
 
 	for i := 0; i < 3; i++ {
-		_, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "project", "support", nil)
+		_, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "support", nil)
 		require.NoError(t, err)
 	}
 
@@ -210,7 +206,7 @@ func TestGetApiKey(t *testing.T) {
 	require.NoError(t, err)
 
 	apiKeysStore := management.NewApiKeysStore(mgmt)
-	apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "project", "support", nil)
+	apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "support", nil)
 	require.NoError(t, err)
 
 	actor := rbac.NewActor(rbac.ActorAdmin, uuid.New().String(),
@@ -318,7 +314,7 @@ func TestUpdateApiKey(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Create a fresh API key for each test case
-			apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "project", "support", nil)
+			apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "support", nil)
 			require.NoError(t, err)
 
 			// Provision the RBAC tuple so deprovision/update can succeed.
@@ -365,7 +361,7 @@ func TestDeleteApiKey(t *testing.T) {
 	require.NoError(t, err)
 
 	apiKeysStore := management.NewApiKeysStore(mgmt)
-	apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "project", "support", nil)
+	apiKey, err := apiKeysStore.CreateApiKey(ctx, projectID, "Test Key", "support", nil)
 	require.NoError(t, err)
 
 	actor := rbac.NewActor(rbac.ActorAdmin, uuid.New().String(),

--- a/internal/http/controllers/v1/management/oapi/resources.yml
+++ b/internal/http/controllers/v1/management/oapi/resources.yml
@@ -4704,7 +4704,7 @@ paths:
 
     patch:
       summary: Update API key
-      description: Updates an API key's name or description (scope cannot be changed)
+      description: Updates an API key's name, role, or description
       operationId: updateApiKey
       tags:
         - API Keys
@@ -9070,12 +9070,6 @@ components:
               items:
                 $ref: "#/components/schemas/ProjectAdmin"
 
-    ApiKeyScope:
-      type: string
-      enum: [public, secret]
-      description: API key scope - public keys are safe to expose in client-side code
-      example: secret
-
     ApiKey:
       type: object
       required:
@@ -9083,7 +9077,6 @@ components:
         - project_id
         - name
         - value
-        - scope
         - role
         - created_at
         - updated_at
@@ -9103,8 +9096,6 @@ components:
           type: string
           example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
           description: The API key value
-        scope:
-          $ref: "#/components/schemas/ApiKeyScope"
         role:
           $ref: "#/components/schemas/ProjectRole"
         description:
@@ -9123,13 +9114,10 @@ components:
       type: object
       required:
         - name
-        - scope
       properties:
         name:
           type: string
           example: "Production API Key"
-        scope:
-          $ref: "#/components/schemas/ApiKeyScope"
         role:
           $ref: "#/components/schemas/ProjectRole"
         description:

--- a/internal/http/controllers/v1/management/oapi/resources_gen.go
+++ b/internal/http/controllers/v1/management/oapi/resources_gen.go
@@ -25,24 +25,6 @@ const (
 	HttpBearerAuthScopes httpBearerAuthContextKey = "HttpBearerAuth.Scopes"
 )
 
-// Defines values for ApiKeyScope.
-const (
-	Public ApiKeyScope = "public"
-	Secret ApiKeyScope = "secret"
-)
-
-// Valid indicates whether the value is a known member of the ApiKeyScope enum.
-func (e ApiKeyScope) Valid() bool {
-	switch e {
-	case Public:
-		return true
-	case Secret:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for BroadcastState.
 const (
 	BroadcastStateCancelled BroadcastState = "cancelled"
@@ -706,18 +688,12 @@ type ApiKey struct {
 	ProjectId   openapi_types.UUID `json:"project_id"`
 
 	// Role Role within a project
-	Role ProjectRole `json:"role"`
-
-	// Scope API key scope - public keys are safe to expose in client-side code
-	Scope     ApiKeyScope `json:"scope"`
+	Role      ProjectRole `json:"role"`
 	UpdatedAt time.Time   `json:"updated_at"`
 
 	// Value The API key value
 	Value string `json:"value"`
 }
-
-// ApiKeyScope API key scope - public keys are safe to expose in client-side code
-type ApiKeyScope string
 
 // AuthCallbackRequest defines model for AuthCallbackRequest.
 type AuthCallbackRequest struct {
@@ -848,9 +824,6 @@ type CreateApiKey struct {
 
 	// Role Role within a project
 	Role *ProjectRole `json:"role,omitempty"`
-
-	// Scope API key scope - public keys are safe to expose in client-side code
-	Scope ApiKeyScope `json:"scope"`
 }
 
 // CreateBroadcast defines model for CreateBroadcast.

--- a/internal/rbac/access/access.go
+++ b/internal/rbac/access/access.go
@@ -78,6 +78,56 @@ func UpdateApiKeyRole(ctx context.Context, engine *rbac.Engine, keyID, projectID
 	return ProvisionApiKey(ctx, engine, keyID, projectID, newRole)
 }
 
+// Grant is a single (resource, verb) entry in a custom permission set. It maps
+// to one direct relation tuple written onto the project-scoped resource object.
+//
+//	{Resource: "inbox", Verb: rbac.Read}  →  user:<policy-id> read inbox:<project-id>
+type Grant struct {
+	Resource string
+	Verb     rbac.Permission
+}
+
+// PolicyGrantTuples returns the tuples that grant an access policy a custom
+// permission set. Each grant becomes a direct relation tuple on the
+// project-scoped resource object. The policyID is the access policy's UUID,
+// used as the RBAC user identity so that checks via [rbac.Actor.UserKey]
+// resolve against these grants.
+//
+// Use this for policies that carry an explicit scope rather than one of the
+// four role presets (see [ApiKeyRoleTuples]).
+func PolicyGrantTuples(policyID, projectID uuid.UUID, grants []Grant) []rbac.Tuple {
+	user := "user:" + policyID.String()
+	tuples := make([]rbac.Tuple, 0, len(grants))
+	for _, g := range grants {
+		tuples = append(tuples, rbac.Tuple{
+			User:     user,
+			Relation: string(g.Verb),
+			Object:   rbac.ProjectResourceScope(g.Resource, projectID),
+		})
+	}
+	return tuples
+}
+
+// ProvisionPolicyGrants writes the custom permission-set tuples for an access
+// policy. Call this when a policy with a custom scope is created. It is a no-op
+// when grants is empty.
+func ProvisionPolicyGrants(ctx context.Context, engine *rbac.Engine, policyID, projectID uuid.UUID, grants []Grant) error {
+	if err := engine.WriteTuples(ctx, PolicyGrantTuples(policyID, projectID, grants)); err != nil {
+		return fmt.Errorf("access: failed to provision grants for policy %s: %w", policyID, err)
+	}
+	return nil
+}
+
+// DeprovisionPolicyGrants removes the custom permission-set tuples created by
+// [ProvisionPolicyGrants]. Call this when a policy is deleted, or before
+// rewriting its scope. It is a no-op when grants is empty.
+func DeprovisionPolicyGrants(ctx context.Context, engine *rbac.Engine, policyID, projectID uuid.UUID, grants []Grant) error {
+	if err := engine.DeleteTuples(ctx, PolicyGrantTuples(policyID, projectID, grants)); err != nil {
+		return fmt.Errorf("access: failed to deprovision grants for policy %s: %w", policyID, err)
+	}
+	return nil
+}
+
 // ProjectTuples returns the tuples that link a project to its parent
 // organization and connect every resource type to the project. These tuples
 // are required for project-scoped permission checks to resolve correctly

--- a/internal/rbac/access/grants_test.go
+++ b/internal/rbac/access/grants_test.go
@@ -1,0 +1,78 @@
+package access
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/rbac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyGrantTuples(t *testing.T) {
+	t.Parallel()
+
+	policyID := uuid.New()
+	projectID := uuid.New()
+
+	grants := []Grant{
+		{Resource: "inbox", Verb: rbac.Read},
+		{Resource: "users", Verb: rbac.Read},
+	}
+
+	expected := []rbac.Tuple{
+		{User: "user:" + policyID.String(), Relation: "read", Object: "inbox:" + projectID.String()},
+		{User: "user:" + policyID.String(), Relation: "read", Object: "users:" + projectID.String()},
+	}
+
+	assert.Equal(t, expected, PolicyGrantTuples(policyID, projectID, grants))
+}
+
+func TestPolicyGrantTuplesEmpty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, PolicyGrantTuples(uuid.New(), uuid.New(), nil))
+}
+
+// TestProvisionPolicyGrants verifies that a custom permission set resolves
+// through the direct-grant path independently of the four role presets: only
+// the exact (resource, verb) pairs granted are allowed, and deprovisioning
+// removes them.
+func TestProvisionPolicyGrants(t *testing.T) {
+	t.Parallel()
+
+	engine := rbac.NewTestEngine(t)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	policyID := uuid.New()
+
+	// A custom read-only scope on inbox + users only — no role preset, and no
+	// project resource tuples written: the grants must resolve on their own.
+	grants := []Grant{
+		{Resource: "inbox", Verb: rbac.Read},
+		{Resource: "users", Verb: rbac.Read},
+	}
+	require.NoError(t, ProvisionPolicyGrants(ctx, engine, policyID, projectID, grants))
+
+	actor := rbac.NewActor(rbac.ActorAPIKey, policyID.String(),
+		rbac.WithOrganizationID(orgID),
+		rbac.WithProjectID(projectID),
+	)
+	actorCtx := rbac.WithActor(ctx, actor)
+
+	// Granted: read on inbox and users.
+	assert.NoError(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.NoError(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("users", projectID)))
+
+	// Not granted: write verbs on the same resources, or read on others.
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Create, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Update, rbac.ProjectResourceScope("users", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("campaigns", projectID)))
+
+	// Deprovisioning removes the grants.
+	require.NoError(t, DeprovisionPolicyGrants(ctx, engine, policyID, projectID, grants))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("users", projectID)))
+}

--- a/internal/rbac/model.go
+++ b/internal/rbac/model.go
@@ -109,6 +109,23 @@ func union(children ...*openfgav1.Userset) *openfgav1.Userset {
 //
 // This follows the Google Zanzibar pattern where each resource type inherits
 // permissions from its parent container.
+//
+// # Custom permission sets
+//
+// Each resource CRUD relation is the union of a direct assignment and the
+// project-role path:
+//
+//	read: this OR project.<role-required-for-read>
+//
+// The project-role path expresses the four role presets (support/client/editor/
+// admin). The direct assignment lets an access policy be granted an explicit,
+// arbitrary scope by writing a tuple straight onto the resource, e.g.
+//
+//	user:<policy-id> → read → inbox:<project-id>
+//
+// This is how access policies carry a custom permission set (resource + verb
+// pairs) without being pinned to one of the four presets. See the access
+// package for the tuple-building helpers.
 func Model() []*openfgav1.TypeDefinition {
 	types := []*openfgav1.TypeDefinition{
 		{Type: "user"},
@@ -194,14 +211,21 @@ func Model() []*openfgav1.TypeDefinition {
 			Relations: map[string]*openfgav1.Userset{
 				"project": direct,
 
-				"read":   ttu("project", r.read),
-				"create": ttu("project", r.create),
-				"update": ttu("project", r.update),
-				"delete": ttu("project", r.delete),
+				// Each CRUD relation is the union of a direct grant (a custom
+				// per-policy scope written straight onto the resource) and the
+				// project-role preset path.
+				"read":   union(direct, ttu("project", r.read)),
+				"create": union(direct, ttu("project", r.create)),
+				"update": union(direct, ttu("project", r.update)),
+				"delete": union(direct, ttu("project", r.delete)),
 			},
 			Metadata: &openfgav1.Metadata{
 				Relations: map[string]*openfgav1.RelationMetadata{
 					"project": directlyRelated(typeRef("project")),
+					"read":    directlyRelated(typeRef("user")),
+					"create":  directlyRelated(typeRef("user")),
+					"update":  directlyRelated(typeRef("user")),
+					"delete":  directlyRelated(typeRef("user")),
 				},
 			},
 		})

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -48,14 +48,27 @@ type Actor struct {
 	// resource and verb.
 	SubjectID uuid.UUID
 
-	// OwnData reports whether the actor is confined to its own records. It is
-	// set only for verified end-user actors ([ActorEndUser]) whose auth method
-	// carries the "own" subject scope; such actors are bound to their verified
-	// subject regardless of any client-supplied identifier. A verified end user
-	// configured for "all" data acts across subjects (like a backend key), so
-	// OwnData is false. See [Actor.SubjectID].
-	OwnData bool
+	// Scope is the data boundary the actor acts within. The zero value (and
+	// [DataScopeAll]) acts across every subject's records, like a backend key;
+	// [DataScopeOwn] is set only for verified end-user actors ([ActorEndUser])
+	// whose auth method carries the "own" subject scope, binding them to their
+	// verified subject regardless of any client-supplied identifier. See
+	// [Actor.SubjectID].
+	Scope DataScope
 }
+
+// DataScope is the data boundary an actor acts within. It is a small enum rather
+// than a bool so the boundary can grow new values without changing the actor
+// option signature.
+type DataScope string
+
+const (
+	// DataScopeAll acts across every subject's records (the default: backend
+	// keys and admins).
+	DataScopeAll DataScope = "all"
+	// DataScopeOwn confines a verified end user to its own records.
+	DataScopeOwn DataScope = "own"
+)
 
 // ActorOption configures optional fields on an [Actor].
 type ActorOption func(*Actor)
@@ -83,12 +96,12 @@ func WithSubjectID(id uuid.UUID) ActorOption {
 	}
 }
 
-// WithOwnData confines the actor to its own records. Use this for verified
-// end-user actors whose auth method has the "own" subject scope. See
-// [Actor.OwnData].
-func WithOwnData(own bool) ActorOption {
+// WithScope sets the data boundary the actor acts within. Use [DataScopeOwn]
+// for verified end-user actors whose auth method has the "own" subject scope.
+// See [Actor.Scope].
+func WithScope(scope DataScope) ActorOption {
 	return func(a *Actor) {
-		a.OwnData = own
+		a.Scope = scope
 	}
 }
 

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -10,8 +10,9 @@ import (
 type ActorType string
 
 const (
-	ActorAdmin  ActorType = "admin"
-	ActorAPIKey ActorType = "api_key"
+	ActorAdmin   ActorType = "admin"
+	ActorAPIKey  ActorType = "api_key"
+	ActorEndUser ActorType = "end_user"
 )
 
 const (
@@ -35,6 +36,25 @@ type Actor struct {
 	ID             string
 	OrganizationID uuid.UUID
 	ProjectID      uuid.UUID
+
+	// SubjectID is the resolved internal Lunogram user (subject) id for
+	// end-user actors ([ActorEndUser]). It is the zero UUID for admins and API
+	// keys.
+	//
+	// Authorization is always decided in OpenFGA against the policy identity
+	// ([Actor.UserKey]); SubjectID never participates in the permission check.
+	// It exists so handlers can scope queries to the verified user's own rows
+	// (e.g. WHERE user_id = SubjectID) once the policy has authorized the
+	// resource and verb.
+	SubjectID uuid.UUID
+
+	// OwnData reports whether the actor is confined to its own records. It is
+	// set only for verified end-user actors ([ActorEndUser]) whose auth method
+	// carries the "own" subject scope; such actors are bound to their verified
+	// subject regardless of any client-supplied identifier. A verified end user
+	// configured for "all" data acts across subjects (like a backend key), so
+	// OwnData is false. See [Actor.SubjectID].
+	OwnData bool
 }
 
 // ActorOption configures optional fields on an [Actor].
@@ -51,6 +71,24 @@ func WithOrganizationID(id uuid.UUID) ActorOption {
 func WithProjectID(id uuid.UUID) ActorOption {
 	return func(a *Actor) {
 		a.ProjectID = id
+	}
+}
+
+// WithSubjectID sets the resolved internal user (subject) id on the actor. Use
+// this for end-user actors so handlers can scope queries to the verified user's
+// own rows. See [Actor.SubjectID].
+func WithSubjectID(id uuid.UUID) ActorOption {
+	return func(a *Actor) {
+		a.SubjectID = id
+	}
+}
+
+// WithOwnData confines the actor to its own records. Use this for verified
+// end-user actors whose auth method has the "own" subject scope. See
+// [Actor.OwnData].
+func WithOwnData(own bool) ActorOption {
+	return func(a *Actor) {
+		a.OwnData = own
 	}
 }
 

--- a/internal/store/management/apikeys.go
+++ b/internal/store/management/apikeys.go
@@ -2,8 +2,6 @@ package management
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,23 +19,36 @@ func (keys ApiKeys) OAPI() []oapi.ApiKey {
 	return results
 }
 
+// ApiKey is the api_key flavour of an auth method, joining auth_methods with
+// auth_method_api_keys. It powers the legacy /keys endpoints.
 type ApiKey struct {
-	ID          uuid.UUID `db:"id"`
-	ProjectID   uuid.UUID `db:"project_id"`
-	Value       string    `db:"value"`
-	Scope       *string   `db:"scope"`
-	Name        string    `db:"name"`
-	Description *string   `db:"description"`
-	Role        string    `db:"role"`
-	CreatedAt   time.Time `db:"created_at"`
-	UpdatedAt   time.Time `db:"updated_at"`
+	ID           uuid.UUID `db:"id"`
+	ProjectID    uuid.UUID `db:"project_id"`
+	SecretPrefix string    `db:"secret_prefix"`
+	Scope        *string   `db:"scope"`
+	Name         string    `db:"name"`
+	Description  *string   `db:"description"`
+	Role         string    `db:"role"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
+
+	// Plaintext holds the full secret and is populated only by CreateApiKey, so
+	// the value is shown to the caller exactly once on creation.
+	Plaintext string `db:"-"`
 }
 
 func (k *ApiKey) OAPI() oapi.ApiKey {
+	// The full secret is returned only on creation (Plaintext); afterwards only
+	// the display prefix is exposed.
+	value := k.Plaintext
+	if value == "" {
+		value = k.SecretPrefix
+	}
+
 	result := oapi.ApiKey{
 		Id:        k.ID,
 		ProjectId: k.ProjectID,
-		Value:     k.Value,
+		Value:     value,
 		Name:      k.Name,
 		Role:      oapi.ProjectRole(k.Role),
 		CreatedAt: k.CreatedAt,
@@ -63,66 +74,62 @@ type ApiKeysStore struct {
 	db store.DB
 }
 
-// generateKeyValue generates a cryptographically secure 32-byte random value encoded as hex
-func generateKeyValue() (string, error) {
-	bytes := make([]byte, 32)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
-}
+// apiKeySelect is the shared projection joining an auth method to its api-key
+// credential. Callers append their own WHERE clause.
+const apiKeySelect = `
+	SELECT m.id, m.project_id, k.secret_prefix, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at
+	FROM auth_methods m
+	JOIN auth_method_api_keys k ON k.auth_method_id = m.id`
 
 func (s *ApiKeysStore) CreateApiKey(ctx context.Context, projectID uuid.UUID, name string, scope string, role string, description *string) (*ApiKey, error) {
-	keyValue, err := generateKeyValue()
+	plaintext, prefix, hash, err := newSecret(scope)
 	if err != nil {
 		return nil, err
 	}
 
-	stmt := `
-	INSERT INTO project_api_keys (project_id, value, scope, name, description, role)
-	VALUES ($1, $2, $3, $4, $5, $6)
-	RETURNING id, project_id, value, scope, name, description, role, created_at, updated_at`
+	// Insert the auth method and its api-key credential atomically via a
+	// data-modifying CTE (store.DB exposes no transaction).
+	id := uuid.New()
+	const stmt = `
+	WITH m AS (
+		INSERT INTO auth_methods (id, project_id, type, name, description, role)
+		VALUES ($1, $2, 'api_key', $3, $4, $5)
+		RETURNING id
+	)
+	INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope)
+	SELECT id, $6, $7, $8 FROM m`
 
-	var apiKey ApiKey
-	err = s.db.GetContext(ctx, &apiKey, stmt, projectID, keyValue, scope, name, description, role)
-	if err != nil {
+	if _, err := s.db.ExecContext(ctx, stmt, id, projectID, name, description, role, hash, prefix, scope); err != nil {
 		return nil, err
 	}
 
-	return &apiKey, nil
+	apiKey, err := s.GetApiKey(ctx, projectID, id)
+	if err != nil {
+		return nil, err
+	}
+	apiKey.Plaintext = plaintext // shown to the caller exactly once
+	return apiKey, nil
 }
 
 func (s *ApiKeysStore) GetApiKey(ctx context.Context, projectID, keyID uuid.UUID) (*ApiKey, error) {
-	stmt := `
-	SELECT id, project_id, value, scope, name, description, role, created_at, updated_at
-	FROM project_api_keys
-	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
+	stmt := apiKeySelect + `
+	WHERE m.id = $1 AND m.project_id = $2 AND m.type = 'api_key' AND m.deleted_at IS NULL`
 
 	var apiKey ApiKey
-	err := s.db.GetContext(ctx, &apiKey, stmt, keyID, projectID)
-	if err != nil {
+	if err := s.db.GetContext(ctx, &apiKey, stmt, keyID, projectID); err != nil {
 		return nil, err
 	}
-
 	return &apiKey, nil
 }
 
 func (s *ApiKeysStore) ListApiKeys(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) (ApiKeys, int, error) {
-	query := `
-	SELECT
-		id,
-		project_id,
-		value,
-		scope,
-		name,
-		description,
-		role,
-		created_at,
-		updated_at,
-		COUNT(*) OVER () AS total_count
-	FROM project_api_keys
-	WHERE project_id = $1 AND deleted_at IS NULL
-	ORDER BY created_at DESC
+	stmt := `
+	SELECT m.id, m.project_id, k.secret_prefix, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at,
+	       COUNT(*) OVER () AS total_count
+	FROM auth_methods m
+	JOIN auth_method_api_keys k ON k.auth_method_id = m.id
+	WHERE m.project_id = $1 AND m.type = 'api_key' AND m.deleted_at IS NULL
+	ORDER BY m.created_at DESC
 	LIMIT $2 OFFSET $3`
 
 	type result struct {
@@ -131,33 +138,27 @@ func (s *ApiKeysStore) ListApiKeys(ctx context.Context, projectID uuid.UUID, pag
 	}
 
 	var results []result
-	err := s.db.SelectContext(ctx, &results, query, projectID, pagination.Limit, pagination.Offset)
-	if err != nil {
+	if err := s.db.SelectContext(ctx, &results, stmt, projectID, pagination.Limit, pagination.Offset); err != nil {
 		return nil, 0, err
 	}
-
 	if len(results) == 0 {
 		return []ApiKey{}, 0, nil
 	}
 
-	total := results[0].TotalCount
 	apiKeys := make([]ApiKey, len(results))
-
-	for index, r := range results {
-		apiKeys[index] = r.ApiKey
+	for i, r := range results {
+		apiKeys[i] = r.ApiKey
 	}
-
-	return apiKeys, total, nil
+	return apiKeys, results[0].TotalCount, nil
 }
 
 func (s *ApiKeysStore) UpdateApiKey(ctx context.Context, projectID, keyID uuid.UUID, name *string, role *string, description *string) error {
 	stmt := `
-	UPDATE project_api_keys
-	SET
-		name = COALESCE($1, name),
-		role = COALESCE($2, role),
-		description = COALESCE($3, description)
-	WHERE id = $4 AND project_id = $5 AND deleted_at IS NULL`
+	UPDATE auth_methods
+	SET name        = COALESCE($1, name),
+	    role        = COALESCE($2, role),
+	    description = COALESCE($3, description)
+	WHERE id = $4 AND project_id = $5 AND type = 'api_key' AND deleted_at IS NULL`
 
 	_, err := s.db.ExecContext(ctx, stmt, name, role, description, keyID, projectID)
 	return err
@@ -165,9 +166,9 @@ func (s *ApiKeysStore) UpdateApiKey(ctx context.Context, projectID, keyID uuid.U
 
 func (s *ApiKeysStore) DeleteApiKey(ctx context.Context, projectID, keyID uuid.UUID) error {
 	stmt := `
-	UPDATE project_api_keys
+	UPDATE auth_methods
 	SET deleted_at = NOW()
-	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
+	WHERE id = $1 AND project_id = $2 AND type = 'api_key' AND deleted_at IS NULL`
 
 	_, err := s.db.ExecContext(ctx, stmt, keyID, projectID)
 	return err

--- a/internal/store/management/apikeys.go
+++ b/internal/store/management/apikeys.go
@@ -25,7 +25,6 @@ type ApiKey struct {
 	ID           uuid.UUID `db:"id"`
 	ProjectID    uuid.UUID `db:"project_id"`
 	SecretPrefix string    `db:"secret_prefix"`
-	Scope        *string   `db:"scope"`
 	Name         string    `db:"name"`
 	Description  *string   `db:"description"`
 	Role         string    `db:"role"`
@@ -55,10 +54,6 @@ func (k *ApiKey) OAPI() oapi.ApiKey {
 		UpdatedAt: k.UpdatedAt,
 	}
 
-	if k.Scope != nil {
-		result.Scope = oapi.ApiKeyScope(*k.Scope)
-	}
-
 	if k.Description != nil {
 		result.Description = k.Description
 	}
@@ -77,12 +72,12 @@ type ApiKeysStore struct {
 // apiKeySelect is the shared projection joining an auth method to its api-key
 // credential. Callers append their own WHERE clause.
 const apiKeySelect = `
-	SELECT m.id, m.project_id, k.secret_prefix, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at
+	SELECT m.id, m.project_id, k.secret_prefix, m.name, m.description, m.role, m.created_at, m.updated_at
 	FROM auth_methods m
 	JOIN auth_method_api_keys k ON k.auth_method_id = m.id`
 
-func (s *ApiKeysStore) CreateApiKey(ctx context.Context, projectID uuid.UUID, name string, scope string, role string, description *string) (*ApiKey, error) {
-	plaintext, prefix, hash, err := newSecret(scope)
+func (s *ApiKeysStore) CreateApiKey(ctx context.Context, projectID uuid.UUID, name string, role string, description *string) (*ApiKey, error) {
+	plaintext, prefix, hash, err := newSecret()
 	if err != nil {
 		return nil, err
 	}
@@ -96,10 +91,10 @@ func (s *ApiKeysStore) CreateApiKey(ctx context.Context, projectID uuid.UUID, na
 		VALUES ($1, $2, 'api_key', $3, $4, $5)
 		RETURNING id
 	)
-	INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope)
-	SELECT id, $6, $7, $8 FROM m`
+	INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix)
+	SELECT id, $6, $7 FROM m`
 
-	if _, err := s.db.ExecContext(ctx, stmt, id, projectID, name, description, role, hash, prefix, scope); err != nil {
+	if _, err := s.db.ExecContext(ctx, stmt, id, projectID, name, description, role, hash, prefix); err != nil {
 		return nil, err
 	}
 
@@ -124,7 +119,7 @@ func (s *ApiKeysStore) GetApiKey(ctx context.Context, projectID, keyID uuid.UUID
 
 func (s *ApiKeysStore) ListApiKeys(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) (ApiKeys, int, error) {
 	stmt := `
-	SELECT m.id, m.project_id, k.secret_prefix, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at,
+	SELECT m.id, m.project_id, k.secret_prefix, m.name, m.description, m.role, m.created_at, m.updated_at,
 	       COUNT(*) OVER () AS total_count
 	FROM auth_methods m
 	JOIN auth_method_api_keys k ON k.auth_method_id = m.id

--- a/internal/store/management/apikeys_test.go
+++ b/internal/store/management/apikeys_test.go
@@ -28,12 +28,10 @@ func TestApiKeysStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("creates an api key across auth_methods + auth_method_api_keys", func(t *testing.T) {
-		created, err := db.CreateApiKey(ctx, projectID, "web key", ScopePublic, "client", ptr.To("desc"))
+		created, err := db.CreateApiKey(ctx, projectID, "web key", "client", ptr.To("desc"))
 		require.NoError(t, err)
-		assert.True(t, strings.HasPrefix(created.Plaintext, "pk_"), "public key should be pk_ prefixed")
+		assert.True(t, strings.HasPrefix(created.Plaintext, "sk_"), "api keys are sk_ prefixed")
 		assert.Equal(t, created.Plaintext[:secretPrefixLen], created.SecretPrefix)
-		require.NotNil(t, created.Scope)
-		assert.Equal(t, ScopePublic, *created.Scope)
 
 		// Reads never expose the plaintext, only the prefix.
 		got, err := db.GetApiKey(ctx, projectID, created.ID)
@@ -56,7 +54,7 @@ func TestApiKeysStore(t *testing.T) {
 	})
 
 	t.Run("lists, updates, and soft deletes", func(t *testing.T) {
-		created, err := db.CreateApiKey(ctx, projectID, "backend key", ScopeSecret, "support", nil)
+		created, err := db.CreateApiKey(ctx, projectID, "backend key", "support", nil)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(created.Plaintext, "sk_"))
 

--- a/internal/store/management/apikeys_test.go
+++ b/internal/store/management/apikeys_test.go
@@ -1,0 +1,81 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApiKeysStore(t *testing.T) {
+	t.Parallel()
+	db := NewContainerStore(t)
+	ctx := context.Background()
+
+	orgID, err := db.CreateOrganization(ctx, "Keys Org")
+	require.NoError(t, err)
+	projectID, err := db.CreateProject(ctx, Project{
+		OrganizationID: &orgID,
+		Name:           "Keys Project",
+		Timezone:       "UTC",
+		Locale:         "en",
+	})
+	require.NoError(t, err)
+
+	t.Run("creates an api key across auth_methods + auth_method_api_keys", func(t *testing.T) {
+		created, err := db.CreateApiKey(ctx, projectID, "web key", ScopePublic, "client", ptr.To("desc"))
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(created.Plaintext, "pk_"), "public key should be pk_ prefixed")
+		assert.Equal(t, created.Plaintext[:secretPrefixLen], created.SecretPrefix)
+		require.NotNil(t, created.Scope)
+		assert.Equal(t, ScopePublic, *created.Scope)
+
+		// Reads never expose the plaintext, only the prefix.
+		got, err := db.GetApiKey(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		assert.Empty(t, got.Plaintext)
+		assert.Equal(t, created.SecretPrefix, got.SecretPrefix)
+		assert.Equal(t, "client", got.Role)
+
+		// Auth resolves the key by hash of the presented plaintext.
+		resolved, err := db.GetAPIKeyBySecret(created.Plaintext)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID.String(), resolved.ID)
+		assert.Equal(t, projectID, resolved.ProjectID)
+		assert.Equal(t, orgID, resolved.OrganizationID)
+		assert.Equal(t, "client", resolved.Role)
+
+		// A wrong secret does not resolve.
+		_, err = db.GetAPIKeyBySecret("pk_not_a_real_secret")
+		assert.Error(t, err)
+	})
+
+	t.Run("lists, updates, and soft deletes", func(t *testing.T) {
+		created, err := db.CreateApiKey(ctx, projectID, "backend key", ScopeSecret, "support", nil)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(created.Plaintext, "sk_"))
+
+		keys, total, err := db.ListApiKeys(ctx, projectID, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, keys, 2)
+
+		require.NoError(t, db.UpdateApiKey(ctx, projectID, created.ID, nil, ptr.To("editor"), nil))
+		got, err := db.GetApiKey(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "editor", got.Role)
+
+		require.NoError(t, db.DeleteApiKey(ctx, projectID, created.ID))
+		_, err = db.GetApiKey(ctx, projectID, created.ID)
+		assert.True(t, errors.Is(err, store.ErrNoRows))
+
+		// A deleted key no longer authenticates.
+		_, err = db.GetAPIKeyBySecret(created.Plaintext)
+		assert.Error(t, err)
+	})
+}

--- a/internal/store/management/auth.go
+++ b/internal/store/management/auth.go
@@ -11,7 +11,6 @@ type APIKey struct {
 	ID             string    `db:"id"`
 	OrganizationID uuid.UUID `db:"organization_id"`
 	ProjectID      uuid.UUID `db:"project_id"`
-	Scope          *string   `db:"scope"`
 	Name           string    `db:"name"`
 	Description    *string   `db:"description"`
 	CreatedAt      time.Time `db:"created_at"`
@@ -32,7 +31,7 @@ type AuthStore struct {
 // stored.
 func (s *AuthStore) GetAPIKeyBySecret(key string) (*APIKey, error) {
 	query := `
-	SELECT m.id, p.organization_id, m.project_id, k.scope, m.name, m.description, m.created_at, m.updated_at, m.role
+	SELECT m.id, p.organization_id, m.project_id, m.name, m.description, m.created_at, m.updated_at, m.role
 	FROM auth_method_api_keys k
 	JOIN auth_methods m ON m.id = k.auth_method_id
 	JOIN projects p ON p.id = m.project_id

--- a/internal/store/management/auth.go
+++ b/internal/store/management/auth.go
@@ -11,7 +11,6 @@ type APIKey struct {
 	ID             string    `db:"id"`
 	OrganizationID uuid.UUID `db:"organization_id"`
 	ProjectID      uuid.UUID `db:"project_id"`
-	Value          string    `db:"value"`
 	Scope          *string   `db:"scope"`
 	Name           string    `db:"name"`
 	Description    *string   `db:"description"`
@@ -28,16 +27,19 @@ type AuthStore struct {
 	db store.DB
 }
 
+// GetAPIKeyBySecret looks up an API-key auth method by the presented plaintext
+// secret. The secret is matched by its SHA-256 hash; the plaintext is never
+// stored.
 func (s *AuthStore) GetAPIKeyBySecret(key string) (*APIKey, error) {
 	query := `
-	SELECT k.id, p.organization_id, k.project_id, k.value, k.scope, k.name, k.description, k.created_at, k.updated_at, k.role
-	FROM project_api_keys k
-	JOIN projects p ON p.id = k.project_id
-	WHERE value = $1`
+	SELECT m.id, p.organization_id, m.project_id, k.scope, m.name, m.description, m.created_at, m.updated_at, m.role
+	FROM auth_method_api_keys k
+	JOIN auth_methods m ON m.id = k.auth_method_id
+	JOIN projects p ON p.id = m.project_id
+	WHERE k.secret_hash = $1 AND m.deleted_at IS NULL`
 
 	result := APIKey{}
-	err := s.db.Get(&result, query, key)
-	if err != nil {
+	if err := s.db.Get(&result, query, hashSecret(key)); err != nil {
 		return nil, err
 	}
 

--- a/internal/store/management/migrations/1764116038_auth_methods.down.sql
+++ b/internal/store/management/migrations/1764116038_auth_methods.down.sql
@@ -1,0 +1,33 @@
+-- Reverse the normalized authentication model, restoring project_api_keys.
+-- The plaintext secret cannot be recovered from its hash, so the restored value
+-- column holds the hash (unique, non-null) and keys must be reissued.
+
+CREATE TABLE project_api_keys (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    value VARCHAR(255) NOT NULL,
+    scope VARCHAR(20),
+    name VARCHAR(255) NOT NULL,
+    description VARCHAR(2048),
+    role VARCHAR(64) NOT NULL DEFAULT 'support',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+INSERT INTO project_api_keys (id, project_id, value, scope, name, description, role, created_at, updated_at, deleted_at)
+SELECT m.id, m.project_id, k.secret_hash, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at, m.deleted_at
+FROM auth_methods m
+JOIN auth_method_api_keys k ON k.auth_method_id = m.id
+WHERE m.type = 'api_key';
+
+CREATE UNIQUE INDEX project_api_keys_value_uniq ON project_api_keys(value);
+CREATE INDEX project_api_keys_project_id_idx ON project_api_keys(project_id);
+CREATE TRIGGER set_updated_at_project_api_keys BEFORE UPDATE ON project_api_keys
+    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+DROP TABLE auth_method_sessions;
+DROP TABLE auth_method_trusted_issuers;
+DROP TABLE auth_method_api_keys;
+DROP TABLE auth_method_grants;
+DROP TABLE auth_methods;

--- a/internal/store/management/migrations/1764116038_auth_methods.down.sql
+++ b/internal/store/management/migrations/1764116038_auth_methods.down.sql
@@ -6,7 +6,6 @@ CREATE TABLE project_api_keys (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     value VARCHAR(255) NOT NULL,
-    scope VARCHAR(20),
     name VARCHAR(255) NOT NULL,
     description VARCHAR(2048),
     role VARCHAR(64) NOT NULL DEFAULT 'support',
@@ -15,8 +14,8 @@ CREATE TABLE project_api_keys (
     deleted_at TIMESTAMPTZ
 );
 
-INSERT INTO project_api_keys (id, project_id, value, scope, name, description, role, created_at, updated_at, deleted_at)
-SELECT m.id, m.project_id, k.secret_hash, k.scope, m.name, m.description, m.role, m.created_at, m.updated_at, m.deleted_at
+INSERT INTO project_api_keys (id, project_id, value, name, description, role, created_at, updated_at, deleted_at)
+SELECT m.id, m.project_id, k.secret_hash, m.name, m.description, m.role, m.created_at, m.updated_at, m.deleted_at
 FROM auth_methods m
 JOIN auth_method_api_keys k ON k.auth_method_id = m.id
 WHERE m.type = 'api_key';

--- a/internal/store/management/migrations/1764116038_auth_methods.up.sql
+++ b/internal/store/management/migrations/1764116038_auth_methods.up.sql
@@ -47,12 +47,13 @@ CREATE TABLE auth_method_grants (
 );
 
 -- API key credential. The plaintext secret is never stored: only its SHA-256
--- hash (the lookup key) and a short display prefix.
+-- hash (the lookup key) and a short display prefix. API keys are always private
+-- (backend-only); browser/mobile clients authenticate via a trusted issuer or a
+-- short-lived session instead.
 CREATE TABLE auth_method_api_keys (
     auth_method_id UUID PRIMARY KEY REFERENCES auth_methods(id) ON DELETE CASCADE,
     secret_hash TEXT NOT NULL,
-    secret_prefix TEXT NOT NULL,
-    scope VARCHAR(20) NOT NULL DEFAULT 'secret'
+    secret_prefix TEXT NOT NULL
 );
 CREATE UNIQUE INDEX auth_method_api_keys_secret_hash_uniq ON auth_method_api_keys(secret_hash);
 
@@ -82,8 +83,8 @@ INSERT INTO auth_methods (id, project_id, type, name, description, role, created
 SELECT id, project_id, 'api_key', name, description, role, created_at, updated_at, deleted_at
 FROM project_api_keys;
 
-INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope)
-SELECT id, encode(digest(value, 'sha256'), 'hex'), left(value, 11), COALESCE(scope, 'secret')
+INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix)
+SELECT id, encode(digest(value, 'sha256'), 'hex'), left(value, 11)
 FROM project_api_keys;
 
 DROP TABLE project_api_keys;

--- a/internal/store/management/migrations/1764116038_auth_methods.up.sql
+++ b/internal/store/management/migrations/1764116038_auth_methods.up.sql
@@ -20,14 +20,16 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE auth_methods (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    type VARCHAR(32) NOT NULL,
+    type VARCHAR(32) NOT NULL CHECK (type IN ('api_key', 'trusted_issuer', 'session')),
     name VARCHAR(255) NOT NULL,
     description VARCHAR(2048),
     role VARCHAR(64) NOT NULL DEFAULT 'support',
     -- Data boundary: 'all' acts across every subject's records (backend keys),
     -- 'own' confines a verified end-user to their own records. Only meaningful
     -- for verified-subject types (trusted_issuer, session); api_key is 'all'.
-    subject_scope VARCHAR(8) NOT NULL DEFAULT 'all',
+    -- Constrained because an out-of-band value other than 'own' would silently
+    -- fail open to acting across all subjects.
+    subject_scope VARCHAR(8) NOT NULL DEFAULT 'all' CHECK (subject_scope IN ('all', 'own')),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     deleted_at TIMESTAMPTZ

--- a/internal/store/management/migrations/1764116038_auth_methods.up.sql
+++ b/internal/store/management/migrations/1764116038_auth_methods.up.sql
@@ -1,0 +1,87 @@
+-- Migration: normalized authentication model (auth_methods + per-type tables)
+--
+-- Replaces the single project_api_keys table with a supertype/subtype model that
+-- separates authentication (how a client proves identity) from authorization
+-- (what it may do):
+--
+--   auth_methods                 supertype: a configured way to authenticate;
+--                                its id is the RBAC subject. Carries the authz
+--                                role preset.
+--   auth_method_grants           authorization: custom permission set (resource, verb)
+--   auth_method_api_keys         credential: a Lunogram-issued key (secret hashed)
+--   auth_method_trusted_issuers  credential validation: external JWT (JWKS/PEM)
+--   auth_method_sessions         credential minting: short-lived session signing
+--
+-- Existing API keys are migrated into auth_methods + auth_method_api_keys, with
+-- their plaintext hashed in the process (the plaintext is then dropped).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE auth_methods (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    type VARCHAR(32) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description VARCHAR(2048),
+    role VARCHAR(64) NOT NULL DEFAULT 'support',
+    -- Data boundary: 'all' acts across every subject's records (backend keys),
+    -- 'own' confines a verified end-user to their own records. Only meaningful
+    -- for verified-subject types (trusted_issuer, session); api_key is 'all'.
+    subject_scope VARCHAR(8) NOT NULL DEFAULT 'all',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+CREATE INDEX auth_methods_project_id_idx ON auth_methods(project_id);
+CREATE TRIGGER set_updated_at_auth_methods BEFORE UPDATE ON auth_methods
+    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+-- Custom permission set. A method either uses its role preset or these grants.
+CREATE TABLE auth_method_grants (
+    auth_method_id UUID NOT NULL REFERENCES auth_methods(id) ON DELETE CASCADE,
+    resource VARCHAR(64) NOT NULL,
+    verb VARCHAR(16) NOT NULL,
+    PRIMARY KEY (auth_method_id, resource, verb)
+);
+
+-- API key credential. The plaintext secret is never stored: only its SHA-256
+-- hash (the lookup key) and a short display prefix.
+CREATE TABLE auth_method_api_keys (
+    auth_method_id UUID PRIMARY KEY REFERENCES auth_methods(id) ON DELETE CASCADE,
+    secret_hash TEXT NOT NULL,
+    secret_prefix TEXT NOT NULL,
+    scope VARCHAR(20) NOT NULL DEFAULT 'secret'
+);
+CREATE UNIQUE INDEX auth_method_api_keys_secret_hash_uniq ON auth_method_api_keys(secret_hash);
+
+-- Trusted-issuer (BYO-IdP) validation config. Exactly one of jwks_url /
+-- public_cert is set.
+CREATE TABLE auth_method_trusted_issuers (
+    auth_method_id UUID PRIMARY KEY REFERENCES auth_methods(id) ON DELETE CASCADE,
+    jwks_url TEXT,
+    public_cert TEXT,
+    issuer TEXT NOT NULL,
+    audience TEXT,
+    subject_claim VARCHAR(64) NOT NULL DEFAULT 'sub',
+    CHECK ((jwks_url IS NOT NULL) <> (public_cert IS NOT NULL))
+);
+CREATE INDEX auth_method_trusted_issuers_issuer_idx ON auth_method_trusted_issuers(issuer);
+
+-- Short-lived session config. Tokens are signed with a server key (configured,
+-- not per-policy), so only the minted-token lifetime lives here; the sessions
+-- PR adds anything more it needs.
+CREATE TABLE auth_method_sessions (
+    auth_method_id UUID PRIMARY KEY REFERENCES auth_methods(id) ON DELETE CASCADE,
+    ttl_seconds INTEGER NOT NULL DEFAULT 900
+);
+
+-- Migrate existing API keys into the normalized model, hashing the plaintext.
+INSERT INTO auth_methods (id, project_id, type, name, description, role, created_at, updated_at, deleted_at)
+SELECT id, project_id, 'api_key', name, description, role, created_at, updated_at, deleted_at
+FROM project_api_keys;
+
+INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope)
+SELECT id, encode(digest(value, 'sha256'), 'hex'), left(value, 11), COALESCE(scope, 'secret')
+FROM project_api_keys;
+
+DROP TABLE project_api_keys;

--- a/internal/store/management/secrets.go
+++ b/internal/store/management/secrets.go
@@ -1,0 +1,63 @@
+package management
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// secretPrefixLen is the number of leading characters of a secret retained for
+// display/identification (e.g. "pk_" plus 8 hex characters).
+const secretPrefixLen = 11
+
+// Scope values recorded on an API-key credential. Public keys are safe to expose
+// in client-side code; secret keys are backend-only.
+const (
+	ScopePublic = "public"
+	ScopeSecret = "secret"
+)
+
+// generateRandomHex returns a cryptographically secure 32-byte random value,
+// hex-encoded.
+func generateRandomHex() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// hashSecret returns the hex-encoded SHA-256 of a secret. Secrets are stored and
+// looked up by this hash so the plaintext is never persisted. It matches the
+// pgcrypto expression used by the migration: encode(digest(value,'sha256'),'hex').
+func hashSecret(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// secretPrefix returns the leading, non-sensitive portion of a secret.
+func secretPrefix(secret string) string {
+	if len(secret) <= secretPrefixLen {
+		return secret
+	}
+	return secret[:secretPrefixLen]
+}
+
+// newSecret generates a fresh API secret for the given scope, returning the full
+// plaintext (shown to the caller exactly once), its display prefix, and the hash
+// to persist. Public keys are prefixed "pk_" and secret keys "sk_" so they are
+// recognisable and detectable by secret scanners.
+func newSecret(scope string) (plaintext, prefix, hash string, err error) {
+	raw, err := generateRandomHex()
+	if err != nil {
+		return "", "", "", err
+	}
+
+	tag := "sk_"
+	if scope == ScopePublic {
+		tag = "pk_"
+	}
+
+	plaintext = tag + raw
+	return plaintext, secretPrefix(plaintext), hashSecret(plaintext), nil
+}

--- a/internal/store/management/secrets.go
+++ b/internal/store/management/secrets.go
@@ -7,15 +7,8 @@ import (
 )
 
 // secretPrefixLen is the number of leading characters of a secret retained for
-// display/identification (e.g. "pk_" plus 8 hex characters).
+// display/identification (e.g. "sk_" plus 8 hex characters).
 const secretPrefixLen = 11
-
-// Scope values recorded on an API-key credential. Public keys are safe to expose
-// in client-side code; secret keys are backend-only.
-const (
-	ScopePublic = "public"
-	ScopeSecret = "secret"
-)
 
 // generateRandomHex returns a cryptographically secure 32-byte random value,
 // hex-encoded.
@@ -43,21 +36,16 @@ func secretPrefix(secret string) string {
 	return secret[:secretPrefixLen]
 }
 
-// newSecret generates a fresh API secret for the given scope, returning the full
-// plaintext (shown to the caller exactly once), its display prefix, and the hash
-// to persist. Public keys are prefixed "pk_" and secret keys "sk_" so they are
-// recognisable and detectable by secret scanners.
-func newSecret(scope string) (plaintext, prefix, hash string, err error) {
+// newSecret generates a fresh API secret, returning the full plaintext (shown to
+// the caller exactly once), its display prefix, and the hash to persist. Keys are
+// prefixed "sk_" so they are recognisable and detectable by secret scanners. API
+// keys are always private (backend-only); there is no browser-safe key variant.
+func newSecret() (plaintext, prefix, hash string, err error) {
 	raw, err := generateRandomHex()
 	if err != nil {
 		return "", "", "", err
 	}
 
-	tag := "sk_"
-	if scope == ScopePublic {
-		tag = "pk_"
-	}
-
-	plaintext = tag + raw
+	plaintext = "sk_" + raw
 	return plaintext, secretPrefix(plaintext), hashSecret(plaintext), nil
 }


### PR DESCRIPTION
First PR in the **client-side API access** series. Foundation only — **additive and backward-compatible**; nothing is wired into request handling yet, so existing API-key behaviour is unchanged.

## What's here

### RBAC / OpenFGA (`internal/rbac`)
- Each resource's `read/create/update/delete` relation is now `union(direct, ttu(project, role))`, with metadata permitting direct `user` grants. An access policy can therefore carry a **custom permission set** as plain tuples (`user:<policyID> read inbox:<proj>`), resolved entirely inside OpenFGA. The four role presets resolve exactly as before.
- New `ActorEndUser` actor type and `Actor.SubjectID` (+ `WithSubjectID`): the permission decision stays in OpenFGA against the **policy identity**; `SubjectID` is only used to scope queries to a verified user's own rows.
- New `access.Grant` + `ProvisionPolicyGrants` / `DeprovisionPolicyGrants`, with tests proving custom grants resolve to exactly the granted (resource, verb) pairs and nothing else.

### Migration (`1764116038_access_policies`)
- Renames `project_api_keys` → `access_policies`; adds the `type` discriminator (default `api_key`) and `grants` / `issuer_config` / `session_config` JSONB columns; makes the secret `value` nullable.
- Recreates `project_api_keys` as an **auto-updatable compatibility view** so the existing API-key store and auth lookups keep working untouched.

## Verification
- `go build ./...`, `go vet ./internal/rbac/...`, `go test ./internal/rbac/...` all green; gofmt clean.
- Migration validated **up and down** against Postgres 18, including the `INSERT … RETURNING` and soft-delete patterns the current store uses.

## Not in this PR (subsequent PRs in the series)
access_policies store CRUD · Phase-1 hardening (scope enforcement, secret hashing + `pk_`/`sk_` prefixes, origin allowlist + CORS, rate limiting) · `/access-policies` API + console UI · JWKS trusted-issuer + sessions · own-data reads + event allow-list · SDK/docs.
