### PR TITLE
feat(store): AuthMethod store over the normalized tables

### DIFF
--- a/internal/store/management/auth_methods.go
+++ b/internal/store/management/auth_methods.go
@@ -1,0 +1,416 @@
+package management
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/store"
+)
+
+// MethodType identifies how an auth method authenticates a client.
+type MethodType string
+
+const (
+	MethodTypeAPIKey        MethodType = "api_key"
+	MethodTypeTrustedIssuer MethodType = "trusted_issuer"
+	MethodTypeSession       MethodType = "session"
+)
+
+// Subject-scope values recorded on an auth method. They define the data
+// boundary: SubjectScopeAll acts across every subject's records (the only valid
+// value for api_key), while SubjectScopeOwn confines a verified end user to
+// their own records.
+const (
+	SubjectScopeAll = "all"
+	SubjectScopeOwn = "own"
+)
+
+// Grant is one (resource, verb) entry in an auth method's custom permission set.
+type Grant struct {
+	Resource string
+	Verb     string
+}
+
+// TrustedIssuer holds the external-JWT validation config for a trusted_issuer
+// method. Exactly one of JWKSURL or PublicCert is set.
+type TrustedIssuer struct {
+	JWKSURL      string
+	PublicCert   string
+	Issuer       string
+	Audience     string
+	SubjectClaim string
+}
+
+// Session holds the config for a session method.
+type Session struct {
+	TTLSeconds int
+}
+
+// AuthMethod is a configured way for a client to authenticate to the API. The
+// id is the RBAC subject; Role + Grants are the authorization it confers.
+// Type-specific fields are populated according to Type.
+type AuthMethod struct {
+	ID          uuid.UUID
+	ProjectID   uuid.UUID
+	Type        MethodType
+	Name        string
+	Description *string
+	Role        string
+	Grants      []Grant
+
+	// SubjectScope is the data boundary ("all" or "own"). See [SubjectScopeAll].
+	SubjectScope string
+
+	// API key (set for MethodTypeAPIKey).
+	Secret       *string // full plaintext; set only by Create (shown once)
+	SecretPrefix *string
+	Scope        *string
+
+	TrustedIssuer *TrustedIssuer // MethodTypeTrustedIssuer
+	Session       *Session       // MethodTypeSession
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func NewAuthMethodsStore(db store.DB) *AuthMethodsStore {
+	return &AuthMethodsStore{db: db}
+}
+
+type AuthMethodsStore struct {
+	db store.DB
+}
+
+// withinTx runs fn inside a transaction when db is a real *sqlx.DB. When db is
+// already a transaction (e.g. a State built over a *sqlx.Tx), fn runs directly
+// on it so the caller's transaction is reused. Either way fn's writes are
+// atomic.
+func withinTx(ctx context.Context, db store.DB, fn func(sqlx.ExtContext) error) error {
+	beginner, ok := db.(interface {
+		BeginTxx(context.Context, *sql.TxOptions) (*sqlx.Tx, error)
+	})
+	if !ok {
+		return fn(db)
+	}
+
+	tx, err := beginner.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op once committed
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// CreateAuthMethodInput carries the fields to create an auth method. The
+// type-specific block (Scope, TrustedIssuer, Session) must match Type.
+type CreateAuthMethodInput struct {
+	Type          MethodType
+	Name          string
+	Description   *string
+	Role          string
+	SubjectScope  string
+	Scope         *string
+	Grants        []Grant
+	TrustedIssuer *TrustedIssuer
+	Session       *Session
+}
+
+// CreateAuthMethod inserts an auth method, its type-specific credential row, and
+// its grants in a single transaction. For api_key methods the generated secret
+// is returned once on the result's Secret field.
+func (s *AuthMethodsStore) CreateAuthMethod(ctx context.Context, projectID uuid.UUID, in CreateAuthMethodInput) (*AuthMethod, error) {
+	id := uuid.New()
+	var secret *string
+
+	err := withinTx(ctx, s.db, func(q sqlx.ExtContext) error {
+		subjectScope := in.SubjectScope
+		if subjectScope == "" {
+			subjectScope = SubjectScopeAll
+		}
+		if _, err := q.ExecContext(ctx,
+			`INSERT INTO auth_methods (id, project_id, type, name, description, role, subject_scope) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			id, projectID, string(in.Type), in.Name, in.Description, in.Role, subjectScope); err != nil {
+			return err
+		}
+
+		switch in.Type {
+		case MethodTypeAPIKey:
+			scope := ptr.FromOr(in.Scope, ScopeSecret)
+			plaintext, prefix, hash, err := newSecret(scope)
+			if err != nil {
+				return err
+			}
+			secret = &plaintext
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope) VALUES ($1, $2, $3, $4)`,
+				id, hash, prefix, scope); err != nil {
+				return err
+			}
+
+		case MethodTypeTrustedIssuer:
+			ti := ptr.FromOr(in.TrustedIssuer, TrustedIssuer{})
+			subjectClaim := ti.SubjectClaim
+			if subjectClaim == "" {
+				subjectClaim = "sub"
+			}
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO auth_method_trusted_issuers (auth_method_id, jwks_url, public_cert, issuer, audience, subject_claim)
+				 VALUES ($1, $2, $3, $4, $5, $6)`,
+				id,
+				sql.NullString{String: ti.JWKSURL, Valid: ti.JWKSURL != ""},
+				sql.NullString{String: ti.PublicCert, Valid: ti.PublicCert != ""},
+				ti.Issuer,
+				sql.NullString{String: ti.Audience, Valid: ti.Audience != ""},
+				subjectClaim); err != nil {
+				return err
+			}
+
+		case MethodTypeSession:
+			ttl := 900
+			if in.Session != nil && in.Session.TTLSeconds > 0 {
+				ttl = in.Session.TTLSeconds
+			}
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO auth_method_sessions (auth_method_id, ttl_seconds) VALUES ($1, $2)`,
+				id, ttl); err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("management: unknown auth method type %q", in.Type)
+		}
+
+		return insertGrants(ctx, q, id, in.Grants)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	method, err := s.GetAuthMethod(ctx, projectID, id)
+	if err != nil {
+		return nil, err
+	}
+	method.Secret = secret // shown to the caller exactly once
+	return method, nil
+}
+
+// insertGrants writes a method's permission set. It runs on a transaction (or
+// any sqlx executor) so it composes with create/update.
+func insertGrants(ctx context.Context, q sqlx.ExecerContext, methodID uuid.UUID, grants []Grant) error {
+	for _, g := range grants {
+		if _, err := q.ExecContext(ctx,
+			`INSERT INTO auth_method_grants (auth_method_id, resource, verb) VALUES ($1, $2, $3)`,
+			methodID, g.Resource, g.Verb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// authMethodRow is the flattened projection joining an auth method to all three
+// optional credential tables; only the columns for the row's type are non-NULL.
+type authMethodRow struct {
+	ID           uuid.UUID `db:"id"`
+	ProjectID    uuid.UUID `db:"project_id"`
+	Type         string    `db:"type"`
+	Name         string    `db:"name"`
+	Description  *string   `db:"description"`
+	Role         string    `db:"role"`
+	SubjectScope string    `db:"subject_scope"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
+
+	SecretPrefix *string `db:"secret_prefix"`
+	Scope        *string `db:"scope"`
+
+	JWKSURL      *string `db:"jwks_url"`
+	PublicCert   *string `db:"public_cert"`
+	Issuer       *string `db:"issuer"`
+	Audience     *string `db:"audience"`
+	SubjectClaim *string `db:"subject_claim"`
+
+	TTLSeconds *int `db:"ttl_seconds"`
+}
+
+func (r authMethodRow) toMethod() *AuthMethod {
+	m := &AuthMethod{
+		ID:           r.ID,
+		ProjectID:    r.ProjectID,
+		Type:         MethodType(r.Type),
+		Name:         r.Name,
+		Description:  r.Description,
+		Role:         r.Role,
+		SubjectScope: r.SubjectScope,
+		SecretPrefix: r.SecretPrefix,
+		Scope:        r.Scope,
+		CreatedAt:    r.CreatedAt,
+		UpdatedAt:    r.UpdatedAt,
+	}
+	switch m.Type {
+	case MethodTypeTrustedIssuer:
+		m.TrustedIssuer = &TrustedIssuer{
+			JWKSURL:      ptr.From(r.JWKSURL),
+			PublicCert:   ptr.From(r.PublicCert),
+			Issuer:       ptr.From(r.Issuer),
+			Audience:     ptr.From(r.Audience),
+			SubjectClaim: ptr.From(r.SubjectClaim),
+		}
+	case MethodTypeSession:
+		if r.TTLSeconds != nil {
+			m.Session = &Session{TTLSeconds: *r.TTLSeconds}
+		}
+	}
+	return m
+}
+
+// authMethodColumns is the shared projection; authMethodFrom is the join graph.
+// They are kept separate so List can add a window column to the SELECT list
+// without it landing in the FROM clause.
+const authMethodColumns = `m.id, m.project_id, m.type, m.name, m.description, m.role, m.subject_scope, m.created_at, m.updated_at,
+	       k.secret_prefix, k.scope,
+	       t.jwks_url, t.public_cert, t.issuer, t.audience, t.subject_claim,
+	       s.ttl_seconds`
+
+const authMethodFrom = `
+	FROM auth_methods m
+	LEFT JOIN auth_method_api_keys k ON k.auth_method_id = m.id
+	LEFT JOIN auth_method_trusted_issuers t ON t.auth_method_id = m.id
+	LEFT JOIN auth_method_sessions s ON s.auth_method_id = m.id`
+
+func (s *AuthMethodsStore) GetAuthMethod(ctx context.Context, projectID, methodID uuid.UUID) (*AuthMethod, error) {
+	stmt := `SELECT ` + authMethodColumns + authMethodFrom + `
+	WHERE m.id = $1 AND m.project_id = $2 AND m.deleted_at IS NULL`
+
+	var row authMethodRow
+	if err := s.db.GetContext(ctx, &row, stmt, methodID, projectID); err != nil {
+		return nil, err
+	}
+	method := row.toMethod()
+
+	grants, err := s.grantsFor(ctx, []uuid.UUID{methodID})
+	if err != nil {
+		return nil, err
+	}
+	method.Grants = grants[methodID]
+	return method, nil
+}
+
+func (s *AuthMethodsStore) ListAuthMethods(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) ([]AuthMethod, int, error) {
+	stmt := `SELECT ` + authMethodColumns + `,
+	       COUNT(*) OVER () AS total_count` + authMethodFrom + `
+	WHERE m.project_id = $1 AND m.deleted_at IS NULL
+	ORDER BY m.created_at DESC
+	LIMIT $2 OFFSET $3`
+
+	type listRow struct {
+		authMethodRow
+		TotalCount int `db:"total_count"`
+	}
+
+	var rows []listRow
+	if err := s.db.SelectContext(ctx, &rows, stmt, projectID, pagination.Limit, pagination.Offset); err != nil {
+		return nil, 0, err
+	}
+	if len(rows) == 0 {
+		return []AuthMethod{}, 0, nil
+	}
+
+	ids := make([]uuid.UUID, len(rows))
+	for i, r := range rows {
+		ids[i] = r.ID
+	}
+	grants, err := s.grantsFor(ctx, ids)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	methods := make([]AuthMethod, len(rows))
+	for i, r := range rows {
+		m := r.toMethod()
+		m.Grants = grants[m.ID]
+		methods[i] = *m
+	}
+	return methods, rows[0].TotalCount, nil
+}
+
+// grantsFor loads grants for the given auth methods, keyed by method id.
+func (s *AuthMethodsStore) grantsFor(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]Grant, error) {
+	out := make(map[uuid.UUID][]Grant, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	const stmt = `
+	SELECT auth_method_id, resource, verb
+	FROM auth_method_grants
+	WHERE auth_method_id = ANY($1::uuid[])
+	ORDER BY resource, verb`
+
+	var rows []struct {
+		AuthMethodID uuid.UUID `db:"auth_method_id"`
+		Resource     string    `db:"resource"`
+		Verb         string    `db:"verb"`
+	}
+	if err := s.db.SelectContext(ctx, &rows, stmt, pq.Array(ids)); err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.AuthMethodID] = append(out[r.AuthMethodID], Grant{Resource: r.Resource, Verb: r.Verb})
+	}
+	return out, nil
+}
+
+// UpdateAuthMethodInput carries the mutable fields. Nil fields are unchanged;
+// Grants is rewritten only when non-nil (replacing the whole set).
+type UpdateAuthMethodInput struct {
+	Name         *string
+	Description  *string
+	Role         *string
+	SubjectScope *string
+	Grants       []Grant
+}
+
+func (s *AuthMethodsStore) UpdateAuthMethod(ctx context.Context, projectID, methodID uuid.UUID, in UpdateAuthMethodInput) error {
+	return withinTx(ctx, s.db, func(q sqlx.ExtContext) error {
+		if _, err := q.ExecContext(ctx,
+			`UPDATE auth_methods
+			 SET name = COALESCE($1, name), description = COALESCE($2, description),
+			     role = COALESCE($3, role), subject_scope = COALESCE($4, subject_scope)
+			 WHERE id = $5 AND project_id = $6 AND deleted_at IS NULL`,
+			in.Name, in.Description, in.Role, in.SubjectScope, methodID, projectID); err != nil {
+			return err
+		}
+
+		// Replace the whole grant set when provided.
+		if in.Grants != nil {
+			if _, err := q.ExecContext(ctx, `DELETE FROM auth_method_grants WHERE auth_method_id = $1`, methodID); err != nil {
+				return err
+			}
+			if err := insertGrants(ctx, q, methodID, in.Grants); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func (s *AuthMethodsStore) DeleteAuthMethod(ctx context.Context, projectID, methodID uuid.UUID) error {
+	const stmt = `
+	UPDATE auth_methods
+	SET deleted_at = NOW()
+	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
+
+	_, err := s.db.ExecContext(ctx, stmt, methodID, projectID)
+	return err
+}

--- a/internal/store/management/auth_methods.go
+++ b/internal/store/management/auth_methods.go
@@ -3,12 +3,14 @@ package management
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
+	"github.com/lunogram/platform/internal/http/problem"
 	"github.com/lunogram/platform/internal/ptr"
 	"github.com/lunogram/platform/internal/store"
 )
@@ -162,6 +164,24 @@ func (s *AuthMethodsStore) CreateAuthMethod(ctx context.Context, projectID uuid.
 			subjectClaim := ti.SubjectClaim
 			if subjectClaim == "" {
 				subjectClaim = "sub"
+			}
+
+			// A trusted issuer is resolved at auth time by `iss` alone, with no
+			// project context, so the active issuer must be globally unique;
+			// otherwise a token could authenticate against the wrong project.
+			// (Soft-deleted methods keep their child row, so this is enforced
+			// here rather than via a DB constraint that would block re-adding a
+			// deleted issuer.)
+			var existing uuid.UUID
+			err := sqlx.GetContext(ctx, q, &existing,
+				`SELECT m.id FROM auth_method_trusted_issuers t
+				 JOIN auth_methods m ON m.id = t.auth_method_id
+				 WHERE t.issuer = $1 AND m.deleted_at IS NULL LIMIT 1`, ti.Issuer)
+			if err == nil {
+				return problem.ErrConflict(problem.Describe("a trusted issuer is already registered for this iss"))
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return err
 			}
 			if _, err := q.ExecContext(ctx,
 				`INSERT INTO auth_method_trusted_issuers (auth_method_id, jwks_url, public_cert, issuer, audience, subject_claim)

--- a/internal/store/management/auth_methods.go
+++ b/internal/store/management/auth_methods.go
@@ -3,13 +3,13 @@ package management
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/lib/pq"
 	"github.com/lunogram/platform/internal/http/problem"
 	"github.com/lunogram/platform/internal/ptr"
 	"github.com/lunogram/platform/internal/store"
@@ -24,19 +24,21 @@ const (
 	MethodTypeSession       MethodType = "session"
 )
 
-// Subject-scope values recorded on an auth method. They define the data
-// boundary: SubjectScopeAll acts across every subject's records (the only valid
-// value for api_key), while SubjectScopeOwn confines a verified end user to
-// their own records.
+// SubjectScope is the data boundary an auth method acts within: SubjectScopeAll
+// acts across every subject's records (the only valid value for api_key), while
+// SubjectScopeOwn confines a verified end user to their own records.
+type SubjectScope string
+
 const (
-	SubjectScopeAll = "all"
-	SubjectScopeOwn = "own"
+	SubjectScopeAll SubjectScope = "all"
+	SubjectScopeOwn SubjectScope = "own"
 )
 
 // Grant is one (resource, verb) entry in an auth method's custom permission set.
+// The json tags match the aggregate built in the read queries.
 type Grant struct {
-	Resource string
-	Verb     string
+	Resource string `json:"resource"`
+	Verb     string `json:"verb"`
 }
 
 // TrustedIssuer holds the external-JWT validation config for a trusted_issuer
@@ -66,13 +68,12 @@ type AuthMethod struct {
 	Role        string
 	Grants      []Grant
 
-	// SubjectScope is the data boundary ("all" or "own"). See [SubjectScopeAll].
-	SubjectScope string
+	// SubjectScope is the data boundary. See [SubjectScope].
+	SubjectScope SubjectScope
 
-	// API key (set for MethodTypeAPIKey).
-	Secret       *string // full plaintext; set only by Create (shown once)
-	SecretPrefix *string
-	Scope        *string
+	// Secret holds the full plaintext for an api_key method; it is set only by
+	// CreateAuthMethod (shown once) and never populated by reads.
+	Secret *string
 
 	TrustedIssuer *TrustedIssuer // MethodTypeTrustedIssuer
 	Session       *Session       // MethodTypeSession
@@ -89,39 +90,29 @@ type AuthMethodsStore struct {
 	db store.DB
 }
 
-// withinTx runs fn inside a transaction when db is a real *sqlx.DB. When db is
-// already a transaction (e.g. a State built over a *sqlx.Tx), fn runs directly
-// on it so the caller's transaction is reused. Either way fn's writes are
-// atomic.
-func withinTx(ctx context.Context, db store.DB, fn func(sqlx.ExtContext) error) error {
-	beginner, ok := db.(interface {
-		BeginTxx(context.Context, *sql.TxOptions) (*sqlx.Tx, error)
-	})
+// txBeginner is the subset of *sqlx.DB used to start a write transaction. Writes
+// require a real connection pool (not an existing transaction); auth-method
+// writes are never issued through a transaction-backed State.
+type txBeginner interface {
+	BeginTxx(context.Context, *sql.TxOptions) (*sqlx.Tx, error)
+}
+
+func (s *AuthMethodsStore) begin(ctx context.Context) (*sqlx.Tx, error) {
+	db, ok := s.db.(txBeginner)
 	if !ok {
-		return fn(db)
+		return nil, errors.New("management: auth methods store requires a *sqlx.DB for writes")
 	}
-
-	tx, err := beginner.BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() //nolint:errcheck // no-op once committed
-
-	if err := fn(tx); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return db.BeginTxx(ctx, nil)
 }
 
 // CreateAuthMethodInput carries the fields to create an auth method. The
-// type-specific block (Scope, TrustedIssuer, Session) must match Type.
+// type-specific block (TrustedIssuer, Session) must match Type.
 type CreateAuthMethodInput struct {
 	Type          MethodType
 	Name          string
 	Description   *string
 	Role          string
-	SubjectScope  string
-	Scope         *string
+	SubjectScope  SubjectScope
 	Grants        []Grant
 	TrustedIssuer *TrustedIssuer
 	Session       *Session
@@ -131,88 +122,43 @@ type CreateAuthMethodInput struct {
 // its grants in a single transaction. For api_key methods the generated secret
 // is returned once on the result's Secret field.
 func (s *AuthMethodsStore) CreateAuthMethod(ctx context.Context, projectID uuid.UUID, in CreateAuthMethodInput) (*AuthMethod, error) {
-	id := uuid.New()
-	var secret *string
-
-	err := withinTx(ctx, s.db, func(q sqlx.ExtContext) error {
-		subjectScope := in.SubjectScope
-		if subjectScope == "" {
-			subjectScope = SubjectScopeAll
-		}
-		if _, err := q.ExecContext(ctx,
-			`INSERT INTO auth_methods (id, project_id, type, name, description, role, subject_scope) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			id, projectID, string(in.Type), in.Name, in.Description, in.Role, subjectScope); err != nil {
-			return err
-		}
-
-		switch in.Type {
-		case MethodTypeAPIKey:
-			scope := ptr.FromOr(in.Scope, ScopeSecret)
-			plaintext, prefix, hash, err := newSecret(scope)
-			if err != nil {
-				return err
-			}
-			secret = &plaintext
-			if _, err := q.ExecContext(ctx,
-				`INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix, scope) VALUES ($1, $2, $3, $4)`,
-				id, hash, prefix, scope); err != nil {
-				return err
-			}
-
-		case MethodTypeTrustedIssuer:
-			ti := ptr.FromOr(in.TrustedIssuer, TrustedIssuer{})
-			subjectClaim := ti.SubjectClaim
-			if subjectClaim == "" {
-				subjectClaim = "sub"
-			}
-
-			// A trusted issuer is resolved at auth time by `iss` alone, with no
-			// project context, so the active issuer must be globally unique;
-			// otherwise a token could authenticate against the wrong project.
-			// (Soft-deleted methods keep their child row, so this is enforced
-			// here rather than via a DB constraint that would block re-adding a
-			// deleted issuer.)
-			var existing uuid.UUID
-			err := sqlx.GetContext(ctx, q, &existing,
-				`SELECT m.id FROM auth_method_trusted_issuers t
-				 JOIN auth_methods m ON m.id = t.auth_method_id
-				 WHERE t.issuer = $1 AND m.deleted_at IS NULL LIMIT 1`, ti.Issuer)
-			if err == nil {
-				return problem.ErrConflict(problem.Describe("a trusted issuer is already registered for this iss"))
-			}
-			if !errors.Is(err, sql.ErrNoRows) {
-				return err
-			}
-			if _, err := q.ExecContext(ctx,
-				`INSERT INTO auth_method_trusted_issuers (auth_method_id, jwks_url, public_cert, issuer, audience, subject_claim)
-				 VALUES ($1, $2, $3, $4, $5, $6)`,
-				id,
-				sql.NullString{String: ti.JWKSURL, Valid: ti.JWKSURL != ""},
-				sql.NullString{String: ti.PublicCert, Valid: ti.PublicCert != ""},
-				ti.Issuer,
-				sql.NullString{String: ti.Audience, Valid: ti.Audience != ""},
-				subjectClaim); err != nil {
-				return err
-			}
-
-		case MethodTypeSession:
-			ttl := 900
-			if in.Session != nil && in.Session.TTLSeconds > 0 {
-				ttl = in.Session.TTLSeconds
-			}
-			if _, err := q.ExecContext(ctx,
-				`INSERT INTO auth_method_sessions (auth_method_id, ttl_seconds) VALUES ($1, $2)`,
-				id, ttl); err != nil {
-				return err
-			}
-
-		default:
-			return fmt.Errorf("management: unknown auth method type %q", in.Type)
-		}
-
-		return insertGrants(ctx, q, id, in.Grants)
-	})
+	tx, err := s.begin(ctx)
 	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op once committed
+
+	id := uuid.New()
+	subjectScope := in.SubjectScope
+	if subjectScope == "" {
+		subjectScope = SubjectScopeAll
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO auth_methods (id, project_id, type, name, description, role, subject_scope) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		id, projectID, string(in.Type), in.Name, in.Description, in.Role, string(subjectScope)); err != nil {
+		return nil, err
+	}
+
+	var secret *string
+	switch in.Type {
+	case MethodTypeAPIKey:
+		secret, err = insertAPIKey(ctx, tx, id)
+	case MethodTypeTrustedIssuer:
+		err = insertTrustedIssuer(ctx, tx, id, in.TrustedIssuer)
+	case MethodTypeSession:
+		err = insertSession(ctx, tx, id, in.Session)
+	default:
+		err = fmt.Errorf("management: unknown auth method type %q", in.Type)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := insertGrants(ctx, tx, id, in.Grants); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
@@ -222,6 +168,70 @@ func (s *AuthMethodsStore) CreateAuthMethod(ctx context.Context, projectID uuid.
 	}
 	method.Secret = secret // shown to the caller exactly once
 	return method, nil
+}
+
+// insertAPIKey mints a fresh sk_ secret for an api_key method, persists its hash
+// and display prefix, and returns the plaintext to show the caller once.
+func insertAPIKey(ctx context.Context, q sqlx.ExecerContext, methodID uuid.UUID) (*string, error) {
+	plaintext, prefix, hash, err := newSecret()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := q.ExecContext(ctx,
+		`INSERT INTO auth_method_api_keys (auth_method_id, secret_hash, secret_prefix) VALUES ($1, $2, $3)`,
+		methodID, hash, prefix); err != nil {
+		return nil, err
+	}
+	return &plaintext, nil
+}
+
+// insertTrustedIssuer persists a trusted_issuer method's validation config. A
+// trusted issuer is resolved at auth time by `iss` alone, with no project
+// context, so the active issuer must be globally unique; otherwise a token could
+// authenticate against the wrong project. (Soft-deleted methods keep their child
+// row, so this is enforced here rather than via a DB constraint that would block
+// re-adding a deleted issuer.)
+func insertTrustedIssuer(ctx context.Context, q sqlx.ExtContext, methodID uuid.UUID, in *TrustedIssuer) error {
+	ti := ptr.FromOr(in, TrustedIssuer{})
+	subjectClaim := ti.SubjectClaim
+	if subjectClaim == "" {
+		subjectClaim = "sub"
+	}
+
+	var existing uuid.UUID
+	err := sqlx.GetContext(ctx, q, &existing,
+		`SELECT m.id FROM auth_method_trusted_issuers t
+		 JOIN auth_methods m ON m.id = t.auth_method_id
+		 WHERE t.issuer = $1 AND m.deleted_at IS NULL LIMIT 1`, ti.Issuer)
+	if err == nil {
+		return problem.ErrConflict(problem.Describe("a trusted issuer is already registered for this iss"))
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	_, err = q.ExecContext(ctx,
+		`INSERT INTO auth_method_trusted_issuers (auth_method_id, jwks_url, public_cert, issuer, audience, subject_claim)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		methodID,
+		sql.NullString{String: ti.JWKSURL, Valid: ti.JWKSURL != ""},
+		sql.NullString{String: ti.PublicCert, Valid: ti.PublicCert != ""},
+		ti.Issuer,
+		sql.NullString{String: ti.Audience, Valid: ti.Audience != ""},
+		subjectClaim)
+	return err
+}
+
+// insertSession persists a session method's config.
+func insertSession(ctx context.Context, q sqlx.ExecerContext, methodID uuid.UUID, in *Session) error {
+	ttl := 900
+	if in != nil && in.TTLSeconds > 0 {
+		ttl = in.TTLSeconds
+	}
+	_, err := q.ExecContext(ctx,
+		`INSERT INTO auth_method_sessions (auth_method_id, ttl_seconds) VALUES ($1, $2)`,
+		methodID, ttl)
+	return err
 }
 
 // insertGrants writes a method's permission set. It runs on a transaction (or
@@ -237,9 +247,11 @@ func insertGrants(ctx context.Context, q sqlx.ExecerContext, methodID uuid.UUID,
 	return nil
 }
 
-// authMethodRow is the flattened projection joining an auth method to all three
-// optional credential tables; only the columns for the row's type are non-NULL.
-type authMethodRow struct {
+// row is the flattened projection of an auth method joined to its optional
+// credential tables, with its grants aggregated as JSON so a method and its
+// permission set load in a single round-trip. Only the columns for the row's
+// type are non-NULL.
+type row struct {
 	ID           uuid.UUID `db:"id"`
 	ProjectID    uuid.UUID `db:"project_id"`
 	Type         string    `db:"type"`
@@ -250,9 +262,6 @@ type authMethodRow struct {
 	CreatedAt    time.Time `db:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at"`
 
-	SecretPrefix *string `db:"secret_prefix"`
-	Scope        *string `db:"scope"`
-
 	JWKSURL      *string `db:"jwks_url"`
 	PublicCert   *string `db:"public_cert"`
 	Issuer       *string `db:"issuer"`
@@ -260,9 +269,16 @@ type authMethodRow struct {
 	SubjectClaim *string `db:"subject_claim"`
 
 	TTLSeconds *int `db:"ttl_seconds"`
+
+	// Grants is a JSON array of {resource, verb} aggregated in the query.
+	Grants []byte `db:"grants"`
+
+	// TotalCount is the window count returned by List; it is absent (zero) for
+	// single-row reads.
+	TotalCount int `db:"total_count"`
 }
 
-func (r authMethodRow) toMethod() *AuthMethod {
+func (r row) toMethod() (*AuthMethod, error) {
 	m := &AuthMethod{
 		ID:           r.ID,
 		ProjectID:    r.ProjectID,
@@ -270,11 +286,14 @@ func (r authMethodRow) toMethod() *AuthMethod {
 		Name:         r.Name,
 		Description:  r.Description,
 		Role:         r.Role,
-		SubjectScope: r.SubjectScope,
-		SecretPrefix: r.SecretPrefix,
-		Scope:        r.Scope,
+		SubjectScope: SubjectScope(r.SubjectScope),
 		CreatedAt:    r.CreatedAt,
 		UpdatedAt:    r.UpdatedAt,
+	}
+	if len(r.Grants) > 0 {
+		if err := json.Unmarshal(r.Grants, &m.Grants); err != nil {
+			return nil, err
+		}
 	}
 	switch m.Type {
 	case MethodTypeTrustedIssuer:
@@ -290,104 +309,69 @@ func (r authMethodRow) toMethod() *AuthMethod {
 			m.Session = &Session{TTLSeconds: *r.TTLSeconds}
 		}
 	}
-	return m
+	return m, nil
 }
 
-// authMethodColumns is the shared projection; authMethodFrom is the join graph.
-// They are kept separate so List can add a window column to the SELECT list
-// without it landing in the FROM clause.
-const authMethodColumns = `m.id, m.project_id, m.type, m.name, m.description, m.role, m.subject_scope, m.created_at, m.updated_at,
-	       k.secret_prefix, k.scope,
-	       t.jwks_url, t.public_cert, t.issuer, t.audience, t.subject_claim,
-	       s.ttl_seconds`
+// The read queries are written out in full (rather than composed from shared
+// fragments) so each is a single, greppable static string. Grants are folded in
+// as a JSON aggregate so a method loads in one round-trip.
+const getAuthMethodQuery = `
+SELECT m.id, m.project_id, m.type, m.name, m.description, m.role, m.subject_scope, m.created_at, m.updated_at,
+       t.jwks_url, t.public_cert, t.issuer, t.audience, t.subject_claim,
+       s.ttl_seconds,
+       COALESCE((
+           SELECT json_agg(json_build_object('resource', g.resource, 'verb', g.verb) ORDER BY g.resource, g.verb)
+           FROM auth_method_grants g
+           WHERE g.auth_method_id = m.id
+       ), '[]') AS grants
+FROM auth_methods m
+LEFT JOIN auth_method_trusted_issuers t ON t.auth_method_id = m.id
+LEFT JOIN auth_method_sessions s ON s.auth_method_id = m.id
+WHERE m.id = $1 AND m.project_id = $2 AND m.deleted_at IS NULL`
 
-const authMethodFrom = `
-	FROM auth_methods m
-	LEFT JOIN auth_method_api_keys k ON k.auth_method_id = m.id
-	LEFT JOIN auth_method_trusted_issuers t ON t.auth_method_id = m.id
-	LEFT JOIN auth_method_sessions s ON s.auth_method_id = m.id`
+const listAuthMethodsQuery = `
+SELECT m.id, m.project_id, m.type, m.name, m.description, m.role, m.subject_scope, m.created_at, m.updated_at,
+       t.jwks_url, t.public_cert, t.issuer, t.audience, t.subject_claim,
+       s.ttl_seconds,
+       COALESCE((
+           SELECT json_agg(json_build_object('resource', g.resource, 'verb', g.verb) ORDER BY g.resource, g.verb)
+           FROM auth_method_grants g
+           WHERE g.auth_method_id = m.id
+       ), '[]') AS grants,
+       COUNT(*) OVER () AS total_count
+FROM auth_methods m
+LEFT JOIN auth_method_trusted_issuers t ON t.auth_method_id = m.id
+LEFT JOIN auth_method_sessions s ON s.auth_method_id = m.id
+WHERE m.project_id = $1 AND m.deleted_at IS NULL
+ORDER BY m.created_at DESC
+LIMIT $2 OFFSET $3`
 
 func (s *AuthMethodsStore) GetAuthMethod(ctx context.Context, projectID, methodID uuid.UUID) (*AuthMethod, error) {
-	stmt := `SELECT ` + authMethodColumns + authMethodFrom + `
-	WHERE m.id = $1 AND m.project_id = $2 AND m.deleted_at IS NULL`
-
-	var row authMethodRow
-	if err := s.db.GetContext(ctx, &row, stmt, methodID, projectID); err != nil {
+	var r row
+	if err := s.db.GetContext(ctx, &r, getAuthMethodQuery, methodID, projectID); err != nil {
 		return nil, err
 	}
-	method := row.toMethod()
-
-	grants, err := s.grantsFor(ctx, []uuid.UUID{methodID})
-	if err != nil {
-		return nil, err
-	}
-	method.Grants = grants[methodID]
-	return method, nil
+	return r.toMethod()
 }
 
 func (s *AuthMethodsStore) ListAuthMethods(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) ([]AuthMethod, int, error) {
-	stmt := `SELECT ` + authMethodColumns + `,
-	       COUNT(*) OVER () AS total_count` + authMethodFrom + `
-	WHERE m.project_id = $1 AND m.deleted_at IS NULL
-	ORDER BY m.created_at DESC
-	LIMIT $2 OFFSET $3`
-
-	type listRow struct {
-		authMethodRow
-		TotalCount int `db:"total_count"`
-	}
-
-	var rows []listRow
-	if err := s.db.SelectContext(ctx, &rows, stmt, projectID, pagination.Limit, pagination.Offset); err != nil {
+	var rows []row
+	if err := s.db.SelectContext(ctx, &rows, listAuthMethodsQuery, projectID, pagination.Limit, pagination.Offset); err != nil {
 		return nil, 0, err
 	}
 	if len(rows) == 0 {
 		return []AuthMethod{}, 0, nil
 	}
 
-	ids := make([]uuid.UUID, len(rows))
-	for i, r := range rows {
-		ids[i] = r.ID
-	}
-	grants, err := s.grantsFor(ctx, ids)
-	if err != nil {
-		return nil, 0, err
-	}
-
 	methods := make([]AuthMethod, len(rows))
-	for i, r := range rows {
-		m := r.toMethod()
-		m.Grants = grants[m.ID]
+	for i := range rows {
+		m, err := rows[i].toMethod()
+		if err != nil {
+			return nil, 0, err
+		}
 		methods[i] = *m
 	}
 	return methods, rows[0].TotalCount, nil
-}
-
-// grantsFor loads grants for the given auth methods, keyed by method id.
-func (s *AuthMethodsStore) grantsFor(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]Grant, error) {
-	out := make(map[uuid.UUID][]Grant, len(ids))
-	if len(ids) == 0 {
-		return out, nil
-	}
-
-	const stmt = `
-	SELECT auth_method_id, resource, verb
-	FROM auth_method_grants
-	WHERE auth_method_id = ANY($1::uuid[])
-	ORDER BY resource, verb`
-
-	var rows []struct {
-		AuthMethodID uuid.UUID `db:"auth_method_id"`
-		Resource     string    `db:"resource"`
-		Verb         string    `db:"verb"`
-	}
-	if err := s.db.SelectContext(ctx, &rows, stmt, pq.Array(ids)); err != nil {
-		return nil, err
-	}
-	for _, r := range rows {
-		out[r.AuthMethodID] = append(out[r.AuthMethodID], Grant{Resource: r.Resource, Verb: r.Verb})
-	}
-	return out, nil
 }
 
 // UpdateAuthMethodInput carries the mutable fields. Nil fields are unchanged;
@@ -396,33 +380,41 @@ type UpdateAuthMethodInput struct {
 	Name         *string
 	Description  *string
 	Role         *string
-	SubjectScope *string
+	SubjectScope *SubjectScope
 	Grants       []Grant
 }
 
 func (s *AuthMethodsStore) UpdateAuthMethod(ctx context.Context, projectID, methodID uuid.UUID, in UpdateAuthMethodInput) error {
-	return withinTx(ctx, s.db, func(q sqlx.ExtContext) error {
-		if _, err := q.ExecContext(ctx,
-			`UPDATE auth_methods
-			 SET name = COALESCE($1, name), description = COALESCE($2, description),
-			     role = COALESCE($3, role), subject_scope = COALESCE($4, subject_scope)
-			 WHERE id = $5 AND project_id = $6 AND deleted_at IS NULL`,
-			in.Name, in.Description, in.Role, in.SubjectScope, methodID, projectID); err != nil {
+	tx, err := s.begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op once committed
+
+	var subjectScope *string
+	if in.SubjectScope != nil {
+		subjectScope = ptr.To(string(*in.SubjectScope))
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE auth_methods
+		 SET name = COALESCE($1, name), description = COALESCE($2, description),
+		     role = COALESCE($3, role), subject_scope = COALESCE($4, subject_scope)
+		 WHERE id = $5 AND project_id = $6 AND deleted_at IS NULL`,
+		in.Name, in.Description, in.Role, subjectScope, methodID, projectID); err != nil {
+		return err
+	}
+
+	// Replace the whole grant set when provided.
+	if in.Grants != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM auth_method_grants WHERE auth_method_id = $1`, methodID); err != nil {
 			return err
 		}
-
-		// Replace the whole grant set when provided.
-		if in.Grants != nil {
-			if _, err := q.ExecContext(ctx, `DELETE FROM auth_method_grants WHERE auth_method_id = $1`, methodID); err != nil {
-				return err
-			}
-			if err := insertGrants(ctx, q, methodID, in.Grants); err != nil {
-				return err
-			}
+		if err := insertGrants(ctx, tx, methodID, in.Grants); err != nil {
+			return err
 		}
+	}
 
-		return nil
-	})
+	return tx.Commit()
 }
 
 func (s *AuthMethodsStore) DeleteAuthMethod(ctx context.Context, projectID, methodID uuid.UUID) error {

--- a/internal/store/management/auth_methods_invariants_test.go
+++ b/internal/store/management/auth_methods_invariants_test.go
@@ -1,0 +1,147 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/lunogram/platform/internal/http/problem"
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthMethodsStoreInvariants covers the security- and correctness-relevant
+// invariants of the auth-method store that are not exercised by the happy-path
+// suite: global trusted-issuer uniqueness, the session default TTL, and the
+// nil-vs-empty grant update semantics.
+func TestAuthMethodsStoreInvariants(t *testing.T) {
+	t.Parallel()
+	db := NewContainerStore(t)
+	ctx := context.Background()
+
+	orgID, err := db.CreateOrganization(ctx, "Invariants Org")
+	require.NoError(t, err)
+
+	// Two distinct projects to prove uniqueness is enforced globally, not
+	// per-project: a trusted issuer is resolved by `iss` alone with no project
+	// context, so a duplicate must never authenticate against another project.
+	projectA, err := db.CreateProject(ctx, Project{
+		OrganizationID: &orgID,
+		Name:           "Invariants Project A",
+		Timezone:       "UTC",
+		Locale:         "en",
+	})
+	require.NoError(t, err)
+	projectB, err := db.CreateProject(ctx, Project{
+		OrganizationID: &orgID,
+		Name:           "Invariants Project B",
+		Timezone:       "UTC",
+		Locale:         "en",
+	})
+	require.NoError(t, err)
+
+	t.Run("trusted_issuer issuer is globally unique across projects", func(t *testing.T) {
+		const iss = "https://shared.example"
+
+		first, err := db.CreateAuthMethod(ctx, projectA, CreateAuthMethodInput{
+			Type: MethodTypeTrustedIssuer,
+			Name: "first idp",
+			Role: "support",
+			TrustedIssuer: &TrustedIssuer{
+				JWKSURL: "https://shared.example/jwks.json",
+				Issuer:  iss,
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// A second ACTIVE method reusing the same iss must be rejected, even in
+		// a different project.
+		_, err = db.CreateAuthMethod(ctx, projectB, CreateAuthMethodInput{
+			Type: MethodTypeTrustedIssuer,
+			Name: "duplicate idp",
+			Role: "support",
+			TrustedIssuer: &TrustedIssuer{
+				JWKSURL: "https://shared.example/other-jwks.json",
+				Issuer:  iss,
+			},
+		})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusConflict, problem.GetStatus(err),
+			"a duplicate active iss must be a conflict")
+
+		// The conflict must not have persisted a row in project B.
+		methods, total, err := db.ListAuthMethods(ctx, projectB, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 0, total)
+		assert.Empty(t, methods)
+	})
+
+	t.Run("session TTL defaults to 900s when unset", func(t *testing.T) {
+		// TTL nil: no Session block at all.
+		nilTTL, err := db.CreateAuthMethod(ctx, projectA, CreateAuthMethodInput{
+			Type: MethodTypeSession,
+			Name: "default-ttl sessions (nil)",
+			Role: "client",
+		})
+		require.NoError(t, err)
+
+		got, err := db.GetAuthMethod(ctx, projectA, nilTTL.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Session)
+		assert.Equal(t, 900, got.Session.TTLSeconds)
+
+		// TTL zero: Session present but TTLSeconds == 0.
+		zeroTTL, err := db.CreateAuthMethod(ctx, projectA, CreateAuthMethodInput{
+			Type:    MethodTypeSession,
+			Name:    "default-ttl sessions (zero)",
+			Role:    "client",
+			Session: &Session{TTLSeconds: 0},
+		})
+		require.NoError(t, err)
+
+		got, err = db.GetAuthMethod(ctx, projectA, zeroTTL.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Session)
+		assert.Equal(t, 900, got.Session.TTLSeconds)
+	})
+
+	t.Run("update grants: nil leaves unchanged, empty clears", func(t *testing.T) {
+		created, err := db.CreateAuthMethod(ctx, projectA, CreateAuthMethodInput{
+			Type: MethodTypeAPIKey,
+			Name: "grant-update key",
+			Role: "client",
+			Grants: []Grant{
+				{Resource: "events", Verb: "create"},
+				{Resource: "users", Verb: "update"},
+			},
+		})
+		require.NoError(t, err)
+
+		// Grants == nil: an update that touches another field must leave the
+		// existing grant set intact.
+		require.NoError(t, db.UpdateAuthMethod(ctx, projectA, created.ID, UpdateAuthMethodInput{
+			Role:   ptr.To("editor"),
+			Grants: nil,
+		}))
+
+		got, err := db.GetAuthMethod(ctx, projectA, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "editor", got.Role)
+		assert.ElementsMatch(t, []Grant{
+			{Resource: "events", Verb: "create"},
+			{Resource: "users", Verb: "update"},
+		}, got.Grants, "nil grants must leave the set unchanged")
+
+		// Grants == []Grant{}: an explicit empty slice clears the set.
+		require.NoError(t, db.UpdateAuthMethod(ctx, projectA, created.ID, UpdateAuthMethodInput{
+			Grants: []Grant{},
+		}))
+
+		got, err = db.GetAuthMethod(ctx, projectA, created.ID)
+		require.NoError(t, err)
+		assert.Empty(t, got.Grants, "an empty grant slice must clear the set")
+	})
+}

--- a/internal/store/management/auth_methods_test.go
+++ b/internal/store/management/auth_methods_test.go
@@ -29,10 +29,9 @@ func TestAuthMethodsStore(t *testing.T) {
 
 	t.Run("creates an api_key method with grants, secret shown once", func(t *testing.T) {
 		created, err := db.CreateAuthMethod(ctx, projectID, CreateAuthMethodInput{
-			Type:  MethodTypeAPIKey,
-			Name:  "web key",
-			Role:  "client",
-			Scope: ptr.To(ScopePublic),
+			Type: MethodTypeAPIKey,
+			Name: "web key",
+			Role: "client",
 			Grants: []Grant{
 				{Resource: "events", Verb: "create"},
 				{Resource: "users", Verb: "update"},
@@ -40,14 +39,11 @@ func TestAuthMethodsStore(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, created.Secret)
-		assert.True(t, strings.HasPrefix(*created.Secret, "pk_"))
+		assert.True(t, strings.HasPrefix(*created.Secret, "sk_"))
 
 		got, err := db.GetAuthMethod(ctx, projectID, created.ID)
 		require.NoError(t, err)
 		assert.Nil(t, got.Secret, "reads never expose the plaintext")
-		require.NotNil(t, got.SecretPrefix)
-		require.NotNil(t, got.Scope)
-		assert.Equal(t, ScopePublic, *got.Scope)
 		assert.Equal(t, SubjectScopeAll, got.SubjectScope, "defaults to all")
 		assert.ElementsMatch(t, created.Grants, got.Grants)
 		assert.Len(t, got.Grants, 2)

--- a/internal/store/management/auth_methods_test.go
+++ b/internal/store/management/auth_methods_test.go
@@ -1,0 +1,133 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMethodsStore(t *testing.T) {
+	t.Parallel()
+	db := NewContainerStore(t)
+	ctx := context.Background()
+
+	orgID, err := db.CreateOrganization(ctx, "AM Org")
+	require.NoError(t, err)
+	projectID, err := db.CreateProject(ctx, Project{
+		OrganizationID: &orgID,
+		Name:           "AM Project",
+		Timezone:       "UTC",
+		Locale:         "en",
+	})
+	require.NoError(t, err)
+
+	t.Run("creates an api_key method with grants, secret shown once", func(t *testing.T) {
+		created, err := db.CreateAuthMethod(ctx, projectID, CreateAuthMethodInput{
+			Type:  MethodTypeAPIKey,
+			Name:  "web key",
+			Role:  "client",
+			Scope: ptr.To(ScopePublic),
+			Grants: []Grant{
+				{Resource: "events", Verb: "create"},
+				{Resource: "users", Verb: "update"},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created.Secret)
+		assert.True(t, strings.HasPrefix(*created.Secret, "pk_"))
+
+		got, err := db.GetAuthMethod(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.Secret, "reads never expose the plaintext")
+		require.NotNil(t, got.SecretPrefix)
+		require.NotNil(t, got.Scope)
+		assert.Equal(t, ScopePublic, *got.Scope)
+		assert.Equal(t, SubjectScopeAll, got.SubjectScope, "defaults to all")
+		assert.ElementsMatch(t, created.Grants, got.Grants)
+		assert.Len(t, got.Grants, 2)
+	})
+
+	t.Run("creates a trusted_issuer method", func(t *testing.T) {
+		created, err := db.CreateAuthMethod(ctx, projectID, CreateAuthMethodInput{
+			Type:         MethodTypeTrustedIssuer,
+			Name:         "acme idp",
+			Role:         "support",
+			SubjectScope: SubjectScopeOwn,
+			TrustedIssuer: &TrustedIssuer{
+				JWKSURL: "https://acme.example/jwks.json",
+				Issuer:  "https://acme.example",
+			},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, created.Secret)
+
+		got, err := db.GetAuthMethod(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.TrustedIssuer)
+		assert.Equal(t, "https://acme.example/jwks.json", got.TrustedIssuer.JWKSURL)
+		assert.Equal(t, "sub", got.TrustedIssuer.SubjectClaim, "defaults to sub")
+		assert.Equal(t, SubjectScopeOwn, got.SubjectScope)
+		assert.Nil(t, got.Session)
+	})
+
+	t.Run("rejects a trusted_issuer with neither jwks nor cert (DB CHECK)", func(t *testing.T) {
+		_, err := db.CreateAuthMethod(ctx, projectID, CreateAuthMethodInput{
+			Type:          MethodTypeTrustedIssuer,
+			Name:          "bad idp",
+			Role:          "support",
+			TrustedIssuer: &TrustedIssuer{Issuer: "https://x"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("creates a session method", func(t *testing.T) {
+		created, err := db.CreateAuthMethod(ctx, projectID, CreateAuthMethodInput{
+			Type:    MethodTypeSession,
+			Name:    "web sessions",
+			Role:    "client",
+			Session: &Session{TTLSeconds: 600},
+		})
+		require.NoError(t, err)
+
+		got, err := db.GetAuthMethod(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Session)
+		assert.Equal(t, 600, got.Session.TTLSeconds)
+	})
+
+	t.Run("lists, updates role + grants, soft deletes", func(t *testing.T) {
+		methods, total, err := db.ListAuthMethods(ctx, projectID, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 3, total)
+		assert.Len(t, methods, 3)
+
+		// Find the api_key method and rewrite its scope.
+		var target AuthMethod
+		for _, m := range methods {
+			if m.Type == MethodTypeAPIKey {
+				target = m
+			}
+		}
+		require.NoError(t, db.UpdateAuthMethod(ctx, projectID, target.ID, UpdateAuthMethodInput{
+			Role:         ptr.To("editor"),
+			SubjectScope: ptr.To(SubjectScopeOwn),
+			Grants:       []Grant{{Resource: "campaigns", Verb: "read"}},
+		}))
+
+		updated, err := db.GetAuthMethod(ctx, projectID, target.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "editor", updated.Role)
+		assert.Equal(t, SubjectScopeOwn, updated.SubjectScope)
+		assert.Equal(t, []Grant{{Resource: "campaigns", Verb: "read"}}, updated.Grants)
+
+		require.NoError(t, db.DeleteAuthMethod(ctx, projectID, target.ID))
+		_, err = db.GetAuthMethod(ctx, projectID, target.ID)
+		assert.True(t, errors.Is(err, store.ErrNoRows))
+	})
+}

--- a/internal/store/management/store.go
+++ b/internal/store/management/store.go
@@ -18,6 +18,7 @@ func NewState(db store.DB) *State {
 		DocumentsStore:            NewDocumentsStore(db),
 		AuthStore:                 NewAuthStore(db),
 		ApiKeysStore:              NewApiKeysStore(db),
+		AuthMethodsStore:          NewAuthMethodsStore(db),
 		ActionsStore:              NewActionsStore(db),
 		SenderIdentitiesStore:     NewSenderIdentitiesStore(db),
 		BroadcastsStore:           NewBroadcastsStore(db),
@@ -39,6 +40,7 @@ type State struct {
 	*DocumentsStore
 	*AuthStore
 	*ApiKeysStore
+	*AuthMethodsStore
 	*ActionsStore
 	*SenderIdentitiesStore
 	*BroadcastsStore


### PR DESCRIPTION
**PR 2 of the client-side API access series (RFC 0001).** Stacked on #243 — review/merge that first.

Adds the data-layer store for the `access_policies` table introduced by the foundation migration. **Not yet wired** into request handling; it's consumed by the management-API PR that follows.

## What's here
- `AccessPolicy` with a **typed API**: `PolicyType` discriminator (`api_key` / `trusted_issuer` / `session`), typed `Grants []Grant`, `*IssuerConfig`, `*SessionConfig`.
- JSONB columns are scanned through an internal row type and decoded into typed fields; empty values are persisted as SQL `NULL` (not `"null"`).
- CRUD: `Create` / `Get` / `List` (with total count) / `Update` (COALESCE semantics; grants rewritten only when provided) / soft `Delete`. Wired into `management.State`.

## Verification
- `go build ./internal/store/...`, `go vet`, gofmt clean.
- **Container test against real Postgres** covers: typed grants/issuer/session round-tripping, list+update, soft delete, and that `api_key` policies surface through the backward-compatible `project_api_keys` view while `trusted_issuer` policies do not.
- The test surfaced and fixed a real bug: `json.RawMessage` cannot scan SQL `NULL` (only `*[]byte` does in `database/sql`).

## Next in the series
PR 3 — transport hardening: scope enforcement in `auth.WithKey`, secret hashing + `pk_`/`sk_` prefixes (show-once), per-project origin allowlist + client CORS tighten, rate limiting.