### PR TITLE
feat(management): hash API secrets at rest, add pk_/sk_ prefixes

### DIFF
--- a/cmd/lunogram/main.go
+++ b/cmd/lunogram/main.go
@@ -184,7 +184,7 @@ func run() error {
 
 	logger.Info("starting http server")
 
-	server, err := v1.NewServer(ctx, logger, conf, db, bucket, jet, pub, req, providersRegisrtry, actionRegistry, rbacEngine)
+	server, err := v1.NewServer(ctx, logger, conf, db, bucket, jet, pub, req, providersRegisrtry, actionRegistry, rbacEngine, limiter)
 	if err != nil {
 		return err
 	}

--- a/console/src/oapi/management.generated.ts
+++ b/console/src/oapi/management.generated.ts
@@ -1914,6 +1914,58 @@ export interface paths {
         patch: operations["updateApiKey"];
         trace?: never;
     };
+    "/api/admin/projects/{projectID}/access-policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List access policies
+         * @description Retrieves a paginated list of access policies for a project
+         */
+        get: operations["listAccessPolicies"];
+        put?: never;
+        /**
+         * Create access policy
+         * @description Creates a new access policy for a project. For api_key policies the secret is returned only in this response.
+         */
+        post: operations["createAccessPolicy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/projects/{projectID}/access-policies/{policyID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get access policy by ID
+         * @description Retrieves a specific access policy. The secret is never included.
+         */
+        get: operations["getAccessPolicy"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete access policy
+         * @description Deletes an access policy, revoking access.
+         */
+        delete: operations["deleteAccessPolicy"];
+        options?: never;
+        head?: never;
+        /**
+         * Update access policy
+         * @description Updates an access policy's name, description, role or grants.
+         */
+        patch: operations["updateAccessPolicy"];
+        trace?: never;
+    };
     "/api/admin/projects/{projectID}/actions": {
         parameters: {
             query?: never;
@@ -4463,6 +4515,90 @@ export interface components {
             /** @example Updated description */
             description?: string;
         };
+        /**
+         * @description How an access policy authenticates a client. `api_key` is a
+         *     Lunogram-issued key; `trusted_issuer` validates external JWTs against a
+         *     configured JWKS/PEM; `session` mints short-lived user-scoped tokens.
+         * @example api_key
+         * @enum {string}
+         */
+        AccessPolicyType: "api_key" | "trusted_issuer" | "session";
+        /** @description A single (resource, verb) entry in a custom permission set. */
+        PermissionGrant: {
+            /** @example inbox */
+            resource: string;
+            /**
+             * @example read
+             * @enum {string}
+             */
+            verb: "read" | "create" | "update" | "delete";
+        };
+        /** @description Verification settings for a trusted_issuer policy. Exactly one of jwks_url or public_cert is set. */
+        TrustedIssuerConfig: {
+            /** @example https://acme.example/.well-known/jwks.json */
+            jwks_url?: string;
+            /** @description PEM-encoded public certificate (alternative to jwks_url). */
+            public_cert?: string;
+            /** @example https://acme.example */
+            iss?: string;
+            /** @example lunogram */
+            aud?: string;
+            /**
+             * @description JWT claim carrying the external user id (defaults to "sub").
+             * @example sub
+             */
+            subject_claim?: string;
+        };
+        /** @description Settings for a session policy. */
+        SessionPolicyConfig: {
+            /**
+             * @description Lifetime of minted session tokens, in seconds.
+             * @example 900
+             */
+            ttl_seconds?: number;
+            role?: components["schemas"]["ProjectRole"];
+        };
+        AccessPolicy: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            project_id: string;
+            type: components["schemas"]["AccessPolicyType"];
+            /** @example Production key */
+            name: string;
+            description?: string;
+            scope?: components["schemas"]["ApiKeyScope"];
+            role: components["schemas"]["ProjectRole"];
+            grants?: components["schemas"]["PermissionGrant"][];
+            issuer_config?: components["schemas"]["TrustedIssuerConfig"];
+            session_config?: components["schemas"]["SessionPolicyConfig"];
+            /**
+             * @description The full secret value. Returned only once, in the response to
+             *     creating an api_key policy, and never again.
+             */
+            secret?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        CreateAccessPolicy: {
+            type: components["schemas"]["AccessPolicyType"];
+            name: string;
+            description?: string;
+            scope?: components["schemas"]["ApiKeyScope"];
+            role?: components["schemas"]["ProjectRole"];
+            /** @description Custom permission set. When set, takes precedence over the role preset. */
+            grants?: components["schemas"]["PermissionGrant"][];
+            issuer_config?: components["schemas"]["TrustedIssuerConfig"];
+            session_config?: components["schemas"]["SessionPolicyConfig"];
+        };
+        UpdateAccessPolicy: {
+            name?: string;
+            description?: string;
+            role?: components["schemas"]["ProjectRole"];
+            grants?: components["schemas"]["PermissionGrant"][];
+        };
         ClientEvent: {
             /**
              * @description The name of the event
@@ -5147,6 +5283,17 @@ export interface components {
             content: {
                 "application/json": components["schemas"]["PaginatedResponse"] & {
                     results: components["schemas"]["ApiKey"][];
+                };
+            };
+        };
+        /** @description Access policies retrieved successfully */
+        AccessPolicyListResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["PaginatedResponse"] & {
+                    results: components["schemas"]["AccessPolicy"][];
                 };
             };
         };
@@ -8958,6 +9105,135 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiKey"];
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    listAccessPolicies: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of items to return */
+                limit?: components["parameters"]["Limit"];
+                /** @description Number of items to skip */
+                offset?: components["parameters"]["Offset"];
+            };
+            header?: never;
+            path: {
+                /** @description The project ID */
+                projectID: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["AccessPolicyListResponse"];
+            default: components["responses"]["Error"];
+        };
+    };
+    createAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project ID */
+                projectID: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAccessPolicy"];
+            };
+        };
+        responses: {
+            /** @description Access policy created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessPolicy"];
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    getAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project ID */
+                projectID: string;
+                /** @description The access policy ID */
+                policyID: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Access policy retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessPolicy"];
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    deleteAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project ID */
+                projectID: string;
+                /** @description The access policy ID */
+                policyID: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Access policy deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    updateAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project ID */
+                projectID: string;
+                /** @description The access policy ID */
+                policyID: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAccessPolicy"];
+            };
+        };
+        responses: {
+            /** @description Access policy updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessPolicy"];
                 };
             };
             default: components["responses"]["Error"];

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Node struct {
 
 	PublicURL  string      `env:"PUBLIC_URL" envDefault:"http://localhost:8080"`
 	Redis      Redis       `envPrefix:"REDIS_"`
+	RateLimit  RateLimit   `envPrefix:"RATE_LIMIT_"`
 	Cluster    Cluster     `envPrefix:"CLUSTER_"`
 	Auth       Auth        `envPrefix:"AUTH_"`
 	Nats       Nats        `envPrefix:"NATS_"`
@@ -60,6 +61,13 @@ type ClerkAuth struct {
 type Redis struct {
 	Address   string `env:"ADDRESS" envDefault:"redis://127.0.0.1:6379"`
 	KeyPrefix string `env:"KEY_PREFIX" envDefault:""`
+}
+
+// RateLimit configures request rate limiting for the client API.
+type RateLimit struct {
+	// ClientPerMinute is the number of client API requests permitted per minute
+	// per access policy (or per IP for unauthenticated requests).
+	ClientPerMinute int `env:"CLIENT_PER_MINUTE" envDefault:"600"`
 }
 
 type Nats struct {

--- a/internal/http/auth/auth.go
+++ b/internal/http/auth/auth.go
@@ -42,6 +42,30 @@ func HMAC(secret []byte) jwt.Keyfunc {
 
 type Handler func(ctx context.Context, token string) (context.Context, error)
 
+// Surface identifies which API an API-key request is authenticating against.
+// Key scope is enforced differently per surface; see [WithKey].
+type Surface int
+
+const (
+	SurfaceManagement Surface = iota
+	SurfaceClient
+)
+
+type requestContextKey struct{}
+
+// withRequest stores the in-flight request on the context so authentication
+// handlers can inspect request headers (e.g. Origin) during scope enforcement.
+func withRequest(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, requestContextKey{}, r)
+}
+
+// RequestFromContext returns the request stored by the authentication
+// middleware, or nil if none is present.
+func RequestFromContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(requestContextKey{}).(*http.Request)
+	return r
+}
+
 // Middleware is a middleware function that authenticates requests by verifying the
 // authorization header. It returns a AuthenticationFunc that checks the authorization
 // header and adds the authenticated session to the request context.
@@ -49,6 +73,7 @@ func Middleware(middleware ...Handler) openapi3filter.AuthenticationFunc {
 	return func(ctx context.Context, filter *openapi3filter.AuthenticationInput) error {
 		req := filter.RequestValidationInput.Request
 		tokenString := GetSession(req)
+		ctx = withRequest(ctx, req)
 
 		for _, m := range middleware {
 			ctx, err := m(ctx, tokenString)
@@ -100,7 +125,22 @@ func WithJWT(config config.Auth, mgmt *management.State) Handler {
 	}
 }
 
-func WithKey(mgmt *management.State) Handler {
+// Scope values recorded on an API key. A missing scope is treated as secret
+// (the conservative default for keys created before scopes were enforced).
+const (
+	ScopePublic = "public"
+	ScopeSecret = "secret"
+)
+
+// WithKey authenticates an API-key request for the given surface and enforces
+// the key's scope:
+//
+//   - public-scoped keys are rejected on the management surface — they exist
+//     only for the client API;
+//   - secret-scoped keys are rejected on the client surface when the request is
+//     browser-originated (carries an Origin header), since secret keys must
+//     never be embedded in client-side code.
+func WithKey(mgmt *management.State, surface Surface) Handler {
 	return func(ctx context.Context, tokenString string) (context.Context, error) {
 		if tokenString == "" {
 			return ctx, ErrUnauthorized
@@ -109,6 +149,10 @@ func WithKey(mgmt *management.State) Handler {
 		key, err := mgmt.GetAPIKeyBySecret(tokenString)
 		if err != nil {
 			return ctx, ErrUnauthorized
+		}
+
+		if err := enforceScope(ctx, surface, key); err != nil {
+			return ctx, err
 		}
 
 		actor := rbac.NewActor(
@@ -120,6 +164,36 @@ func WithKey(mgmt *management.State) Handler {
 
 		return rbac.WithActor(ctx, actor), nil
 	}
+}
+
+// enforceScope applies the per-surface scope rules. It returns ErrUnauthorized
+// (rather than a distinct error) so callers cannot use the response to probe
+// whether a given key exists.
+func enforceScope(ctx context.Context, surface Surface, key *management.APIKey) error {
+	scope := ScopeSecret
+	if key.Scope != nil && *key.Scope != "" {
+		scope = *key.Scope
+	}
+
+	switch surface {
+	case SurfaceManagement:
+		if scope == ScopePublic {
+			return ErrUnauthorized
+		}
+	case SurfaceClient:
+		if scope == ScopeSecret && browserOriginated(ctx) {
+			return ErrUnauthorized
+		}
+	}
+
+	return nil
+}
+
+// browserOriginated reports whether the request carries an Origin header, which
+// browsers attach to cross-origin (and most same-origin non-GET) requests.
+func browserOriginated(ctx context.Context) bool {
+	r := RequestFromContext(ctx)
+	return r != nil && r.Header.Get("Origin") != ""
 }
 
 // OAuthResponse represents the OAuth token response stored in cookies

--- a/internal/http/auth/scope_test.go
+++ b/internal/http/auth/scope_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lunogram/platform/internal/store/management"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnforceScope(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(s string) *string { return &s }
+
+	withOrigin := func() context.Context {
+		r := httptest.NewRequest(http.MethodPost, "/api/client/v1/users", nil)
+		r.Header.Set("Origin", "https://app.example.com")
+		return withRequest(context.Background(), r)
+	}
+	withoutOrigin := func() context.Context {
+		r := httptest.NewRequest(http.MethodPost, "/api/client/v1/users", nil)
+		return withRequest(context.Background(), r)
+	}
+
+	tests := map[string]struct {
+		surface Surface
+		scope   *string
+		ctx     context.Context
+		wantErr bool
+	}{
+		"management rejects public key":                   {SurfaceManagement, ptr(ScopePublic), context.Background(), true},
+		"management allows secret key":                    {SurfaceManagement, ptr(ScopeSecret), context.Background(), false},
+		"management treats missing scope as secret":       {SurfaceManagement, nil, context.Background(), false},
+		"client rejects secret key from browser":          {SurfaceClient, ptr(ScopeSecret), withOrigin(), true},
+		"client allows secret key server-side":            {SurfaceClient, ptr(ScopeSecret), withoutOrigin(), false},
+		"client treats missing scope as secret (browser)": {SurfaceClient, nil, withOrigin(), true},
+		"client allows public key from browser":           {SurfaceClient, ptr(ScopePublic), withOrigin(), false},
+		"client allows public key server-side":            {SurfaceClient, ptr(ScopePublic), withoutOrigin(), false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := enforceScope(tc.ctx, tc.surface, &management.APIKey{Scope: tc.scope})
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrUnauthorized)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/http/controllers/v1/client/oapi/middleware.go
+++ b/internal/http/controllers/v1/client/oapi/middleware.go
@@ -2,12 +2,19 @@ package oapi
 
 import (
 	"errors"
+	"math"
+	"net"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/go-chi/cors"
 	"github.com/lunogram/platform/internal/http/problem"
+	"github.com/lunogram/platform/internal/ratelimit"
+	"github.com/lunogram/platform/internal/rbac"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 )
 
@@ -22,12 +29,62 @@ func Validator(spec *openapi3.T, options openapi3filter.Options) func(next http.
 	})
 }
 
+// CORS configures cross-origin access for the client API. The client API is
+// strictly bearer-authenticated (no cookies), so credentials are disabled and a
+// wildcard origin is safe: a bearer token is never sent ambiently by the
+// browser, so a wildcard cannot be abused the way it can with cookie auth.
+// Per-policy origin allow-listing is enforced after authentication, against the
+// resolved access policy, rather than here.
 func CORS() func(next http.Handler) http.Handler {
 	return cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
-		AllowCredentials: true,
+		AllowCredentials: false,
 		MaxAge:           300,
 	})
+}
+
+// RateLimit limits client API requests to limit requests per window. It keys on
+// the authenticated access policy when present (so each key gets its own
+// budget) and falls back to the client IP for unauthenticated traffic. It must
+// run after authentication so the actor is available on the context.
+//
+// The limiter fails open on Redis errors (see ratelimit.Limiter), so an
+// unavailable Redis never blocks legitimate traffic.
+func RateLimit(limiter *ratelimit.Limiter, limit int, window time.Duration) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			allowed, retryAfter, _ := limiter.Allow(r.Context(), rateLimitKey(r), limit, window)
+			if !allowed {
+				w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+				WriteProblem(w, problem.ErrTooManyRequests())
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// rateLimitKey identifies the rate-limit bucket for a request: the access
+// policy id when authenticated, otherwise the client IP.
+func rateLimitKey(r *http.Request) string {
+	if actor := rbac.FromContext(r.Context()); actor != nil && actor.ID != "" {
+		return "client:key:" + actor.ID
+	}
+	return "client:ip:" + clientIP(r)
+}
+
+// clientIP returns the originating client IP, preferring the first hop in
+// X-Forwarded-For and falling back to the connection's remote address.
+func clientIP(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if first := strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0]); first != "" {
+			return first
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/internal/http/controllers/v1/http.go
+++ b/internal/http/controllers/v1/http.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	nethttp "net/http"
 	"path/filepath"
+	"time"
 
 	"github.com/cloudproud/graceful"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -24,6 +25,7 @@ import (
 	"github.com/lunogram/platform/internal/http/scalar"
 	"github.com/lunogram/platform/internal/providers"
 	"github.com/lunogram/platform/internal/pubsub"
+	"github.com/lunogram/platform/internal/ratelimit"
 	"github.com/lunogram/platform/internal/rbac"
 	"github.com/lunogram/platform/internal/storage"
 	"github.com/lunogram/platform/internal/store"
@@ -39,7 +41,7 @@ var staticFiles embed.FS
 // NewServer constructs a unified HTTP server combining both management and client
 // API endpoints. Management endpoints use JWT+API Key auth, while client endpoints
 // use API Key only authentication.
-func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *store.Connections, storageDriver storage.Storage, jet jetstream.JetStream, pub pubsub.Publisher, req pubsub.Caller, registry *providers.Registry, actionRegistry *actions.Registry, rbacEngine *rbac.Engine) (*http.Server, error) {
+func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *store.Connections, storageDriver storage.Storage, jet jetstream.JetStream, pub pubsub.Publisher, req pubsub.Caller, registry *providers.Registry, actionRegistry *actions.Registry, rbacEngine *rbac.Engine, limiter *ratelimit.Limiter) (*http.Server, error) {
 	mgmtStores := management.NewState(db.Management)
 	usersStore := subjects.NewState(db.Subjects, logger)
 
@@ -81,7 +83,7 @@ func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *st
 		Middlewares: []mgmtoapi.MiddlewareFunc{mgmtoapi.Validator(mgmtSpec, openapi3filter.Options{
 			AuthenticationFunc: auth.Middleware(
 				auth.WithJWT(cfg.Auth, mgmtStores),
-				auth.WithKey(mgmtStores),
+				auth.WithKey(mgmtStores, auth.SurfaceManagement),
 			),
 		})},
 	})
@@ -95,9 +97,12 @@ func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *st
 			Middlewares: []clientoapi.MiddlewareFunc{
 				clientoapi.Validator(clientSpec, openapi3filter.Options{
 					AuthenticationFunc: auth.Middleware(
-						auth.WithKey(mgmtStores),
+						auth.WithKey(mgmtStores, auth.SurfaceClient),
 					),
 				}),
+				// Runs after the validator (and thus after authentication) so
+				// the limiter can key on the authenticated access policy.
+				clientoapi.RateLimit(limiter, cfg.RateLimit.ClientPerMinute, time.Minute),
 			},
 		})
 	})

--- a/internal/http/controllers/v1/management/accesspolicies.go
+++ b/internal/http/controllers/v1/management/accesspolicies.go
@@ -1,0 +1,421 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/lunogram/platform/internal/http/controllers/v1/management/oapi"
+	"github.com/lunogram/platform/internal/http/json"
+	"github.com/lunogram/platform/internal/http/problem"
+	"github.com/lunogram/platform/internal/rbac"
+	"github.com/lunogram/platform/internal/rbac/access"
+	"github.com/lunogram/platform/internal/store"
+	"github.com/lunogram/platform/internal/store/management"
+	"go.uber.org/zap"
+)
+
+func NewAccessPoliciesController(logger *zap.Logger, db *sqlx.DB, engine *rbac.Engine) *AccessPoliciesController {
+	return &AccessPoliciesController{
+		logger: logger,
+		store:  management.NewState(db),
+		engine: engine,
+	}
+}
+
+type AccessPoliciesController struct {
+	logger *zap.Logger
+	store  *management.State
+	engine *rbac.Engine
+}
+
+func (srv *AccessPoliciesController) CreateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID uuid.UUID) {
+	ctx := r.Context()
+	actor := rbac.FromContext(ctx)
+	if err := srv.engine.Allowed(ctx, rbac.Create, rbac.OrganizationScope(actor.OrganizationID)); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	var body oapi.CreateAccessPolicyJSONRequestBody
+	if err := json.Decode(r.Body, &body); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	in, err := buildCreateInput(body)
+	if err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	logger := srv.logger.With(zap.Stringer("project_id", projectID), zap.String("name", in.Name), zap.String("type", string(in.Type)))
+	logger.Info("creating access policy")
+
+	policy, err := srv.store.CreateAccessPolicy(ctx, projectID, in)
+	if err != nil {
+		logger.Error("failed to create access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	if err := srv.provision(ctx, policy); err != nil {
+		logger.Error("failed to provision RBAC for access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	logger.Info("access policy created", zap.Stringer("policy_id", policy.ID))
+	json.Write(w, http.StatusCreated, toOAPIAccessPolicy(policy, true))
+}
+
+func (srv *AccessPoliciesController) ListAccessPolicies(w http.ResponseWriter, r *http.Request, projectID uuid.UUID, params oapi.ListAccessPoliciesParams) {
+	ctx := r.Context()
+	actor := rbac.FromContext(ctx)
+	if err := srv.engine.Allowed(ctx, rbac.Read, rbac.OrganizationScope(actor.OrganizationID)); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	pagination := store.Pagination{Limit: params.Limit.ToInt(), Offset: params.Offset.ToInt()}
+	policies, total, err := srv.store.ListAccessPolicies(ctx, projectID, pagination)
+	if err != nil {
+		srv.logger.Error("failed to list access policies", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	results := make([]oapi.AccessPolicy, len(policies))
+	for i := range policies {
+		// Never include secrets in list responses.
+		results[i] = toOAPIAccessPolicy(&policies[i], false)
+	}
+
+	json.Write(w, http.StatusOK, oapi.AccessPolicyListResponse{
+		Total:   total,
+		Limit:   pagination.Limit,
+		Offset:  pagination.Offset,
+		Results: results,
+	})
+}
+
+func (srv *AccessPoliciesController) GetAccessPolicy(w http.ResponseWriter, r *http.Request, projectID, policyID uuid.UUID) {
+	ctx := r.Context()
+	actor := rbac.FromContext(ctx)
+	if err := srv.engine.Allowed(ctx, rbac.Read, rbac.OrganizationScope(actor.OrganizationID)); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	policy := srv.fetch(ctx, w, projectID, policyID)
+	if policy == nil {
+		return
+	}
+
+	json.Write(w, http.StatusOK, toOAPIAccessPolicy(policy, false))
+}
+
+func (srv *AccessPoliciesController) UpdateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID, policyID uuid.UUID) {
+	ctx := r.Context()
+	actor := rbac.FromContext(ctx)
+	if err := srv.engine.Allowed(ctx, rbac.Update, rbac.OrganizationScope(actor.OrganizationID)); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	var body oapi.UpdateAccessPolicyJSONRequestBody
+	if err := json.Decode(r.Body, &body); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	existing := srv.fetch(ctx, w, projectID, policyID)
+	if existing == nil {
+		return
+	}
+
+	in := management.UpdateAccessPolicyInput{Name: body.Name, Description: body.Description}
+	if body.Role != nil {
+		role := string(*body.Role)
+		in.Role = &role
+	}
+	if body.Grants != nil {
+		in.Grants = toStoreGrants(*body.Grants)
+	}
+
+	if err := srv.enforcePublicWriteOnly(existing, in); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	if err := srv.store.UpdateAccessPolicy(ctx, projectID, policyID, in); err != nil {
+		srv.logger.Error("failed to update access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	updated := srv.fetch(ctx, w, projectID, policyID)
+	if updated == nil {
+		return
+	}
+
+	// Re-provision RBAC only when the effective scope changed.
+	if body.Role != nil || body.Grants != nil {
+		if err := srv.deprovision(ctx, existing); err != nil {
+			srv.logger.Error("failed to deprovision old access policy scope", zap.Error(err))
+			oapi.WriteProblem(w, err)
+			return
+		}
+		if err := srv.provision(ctx, updated); err != nil {
+			srv.logger.Error("failed to provision new access policy scope", zap.Error(err))
+			oapi.WriteProblem(w, err)
+			return
+		}
+	}
+
+	json.Write(w, http.StatusOK, toOAPIAccessPolicy(updated, false))
+}
+
+func (srv *AccessPoliciesController) DeleteAccessPolicy(w http.ResponseWriter, r *http.Request, projectID, policyID uuid.UUID) {
+	ctx := r.Context()
+	actor := rbac.FromContext(ctx)
+	if err := srv.engine.Allowed(ctx, rbac.Delete, rbac.OrganizationScope(actor.OrganizationID)); err != nil {
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	policy := srv.fetch(ctx, w, projectID, policyID)
+	if policy == nil {
+		return
+	}
+
+	if err := srv.store.DeleteAccessPolicy(ctx, projectID, policyID); err != nil {
+		srv.logger.Error("failed to delete access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	if err := srv.deprovision(ctx, policy); err != nil {
+		srv.logger.Error("failed to deprovision RBAC for access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// fetch loads a policy, writing a problem response and returning nil when it is
+// not found or on error.
+func (srv *AccessPoliciesController) fetch(ctx context.Context, w http.ResponseWriter, projectID, policyID uuid.UUID) *management.AccessPolicy {
+	policy, err := srv.store.GetAccessPolicy(ctx, projectID, policyID)
+	if errors.Is(err, store.ErrNoRows) {
+		oapi.WriteProblem(w, problem.ErrNotFound(problem.Describe("access policy not found")))
+		return nil
+	}
+	if err != nil {
+		srv.logger.Error("failed to fetch access policy", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return nil
+	}
+	return policy
+}
+
+// provision writes the RBAC tuples granting a policy its scope: the custom
+// permission set when present, otherwise the role preset.
+func (srv *AccessPoliciesController) provision(ctx context.Context, policy *management.AccessPolicy) error {
+	if len(policy.Grants) > 0 {
+		return access.ProvisionPolicyGrants(ctx, srv.engine, policy.ID, policy.ProjectID, toAccessGrants(policy.Grants))
+	}
+	return access.ProvisionApiKey(ctx, srv.engine, policy.ID, policy.ProjectID, policy.Role)
+}
+
+func (srv *AccessPoliciesController) deprovision(ctx context.Context, policy *management.AccessPolicy) error {
+	if len(policy.Grants) > 0 {
+		return access.DeprovisionPolicyGrants(ctx, srv.engine, policy.ID, policy.ProjectID, toAccessGrants(policy.Grants))
+	}
+	return access.DeprovisionApiKey(ctx, srv.engine, policy.ID, policy.ProjectID, policy.Role)
+}
+
+// enforcePublicWriteOnly rejects an update that would grant a public policy any
+// read access, preserving the invariant that browser-exposed keys are
+// write-only.
+func (srv *AccessPoliciesController) enforcePublicWriteOnly(existing *management.AccessPolicy, in management.UpdateAccessPolicyInput) error {
+	if existing.Scope == nil || *existing.Scope != management.ScopePublic {
+		return nil
+	}
+	if in.Role != nil && *in.Role != rbac.ProjectClient {
+		return problem.ErrBadRequest(problem.Describe("public policies must use the write-only client role"))
+	}
+	for _, g := range in.Grants {
+		if g.Verb == string(rbac.Read) {
+			return problem.ErrBadRequest(problem.Describe("public policies may not be granted read access"))
+		}
+	}
+	return nil
+}
+
+// buildCreateInput validates a create request and maps it to a store input,
+// enforcing the public-key write-only invariant.
+func buildCreateInput(body oapi.CreateAccessPolicy) (management.CreateAccessPolicyInput, error) {
+	in := management.CreateAccessPolicyInput{
+		Type:        management.PolicyType(body.Type),
+		Name:        body.Name,
+		Description: body.Description,
+	}
+	if body.Scope != nil {
+		scope := string(*body.Scope)
+		in.Scope = &scope
+	}
+	if body.Grants != nil {
+		in.Grants = toStoreGrants(*body.Grants)
+	}
+	if body.IssuerConfig != nil {
+		in.IssuerConfig = toStoreIssuerConfig(*body.IssuerConfig)
+	}
+	if body.SessionConfig != nil {
+		in.SessionConfig = toStoreSessionConfig(*body.SessionConfig)
+	}
+
+	role := rbac.ProjectSupport
+	if body.Role != nil {
+		role = string(*body.Role)
+	}
+
+	if in.Scope != nil && *in.Scope == management.ScopePublic {
+		// Public keys are browser-exposed: default to the write-only client
+		// preset and reject any read access.
+		if body.Role == nil {
+			role = rbac.ProjectClient
+		}
+		if role != rbac.ProjectClient {
+			return in, problem.ErrBadRequest(problem.Describe("public policies must use the write-only client role"))
+		}
+		for _, g := range in.Grants {
+			if g.Verb == string(rbac.Read) {
+				return in, problem.ErrBadRequest(problem.Describe("public policies may not be granted read access"))
+			}
+		}
+	}
+	in.Role = role
+
+	return in, nil
+}
+
+func toStoreGrants(grants []oapi.PermissionGrant) []management.Grant {
+	out := make([]management.Grant, len(grants))
+	for i, g := range grants {
+		out[i] = management.Grant{Resource: g.Resource, Verb: string(g.Verb)}
+	}
+	return out
+}
+
+func toAccessGrants(grants []management.Grant) []access.Grant {
+	out := make([]access.Grant, len(grants))
+	for i, g := range grants {
+		out[i] = access.Grant{Resource: g.Resource, Verb: rbac.Permission(g.Verb)}
+	}
+	return out
+}
+
+func toStoreIssuerConfig(c oapi.TrustedIssuerConfig) *management.IssuerConfig {
+	out := &management.IssuerConfig{}
+	if c.JwksUrl != nil {
+		out.JWKSURL = *c.JwksUrl
+	}
+	if c.PublicCert != nil {
+		out.PublicCert = *c.PublicCert
+	}
+	if c.Iss != nil {
+		out.Issuer = *c.Iss
+	}
+	if c.Aud != nil {
+		out.Audience = *c.Aud
+	}
+	if c.SubjectClaim != nil {
+		out.SubjectClaim = *c.SubjectClaim
+	}
+	return out
+}
+
+func toStoreSessionConfig(c oapi.SessionPolicyConfig) *management.SessionConfig {
+	out := &management.SessionConfig{}
+	if c.TtlSeconds != nil {
+		out.TTL = time.Duration(*c.TtlSeconds) * time.Second
+	}
+	if c.Role != nil {
+		out.Role = string(*c.Role)
+	}
+	return out
+}
+
+// toOAPIAccessPolicy maps a stored policy to its API representation. The secret
+// is included only when withSecret is true (the create response).
+func toOAPIAccessPolicy(p *management.AccessPolicy, withSecret bool) oapi.AccessPolicy {
+	out := oapi.AccessPolicy{
+		Id:          p.ID,
+		ProjectId:   p.ProjectID,
+		Type:        oapi.AccessPolicyType(p.Type),
+		Name:        p.Name,
+		Description: p.Description,
+		Role:        oapi.ProjectRole(p.Role),
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+	if p.Scope != nil {
+		scope := oapi.ApiKeyScope(*p.Scope)
+		out.Scope = &scope
+	}
+	if len(p.Grants) > 0 {
+		grants := make([]oapi.PermissionGrant, len(p.Grants))
+		for i, g := range p.Grants {
+			grants[i] = oapi.PermissionGrant{Resource: g.Resource, Verb: oapi.PermissionGrantVerb(g.Verb)}
+		}
+		out.Grants = &grants
+	}
+	if p.IssuerConfig != nil {
+		out.IssuerConfig = toOAPIIssuerConfig(p.IssuerConfig)
+	}
+	if p.SessionConfig != nil {
+		out.SessionConfig = toOAPISessionConfig(p.SessionConfig)
+	}
+	if withSecret {
+		out.Secret = p.Secret
+	}
+	return out
+}
+
+func toOAPIIssuerConfig(c *management.IssuerConfig) *oapi.TrustedIssuerConfig {
+	out := &oapi.TrustedIssuerConfig{}
+	if c.JWKSURL != "" {
+		out.JwksUrl = &c.JWKSURL
+	}
+	if c.PublicCert != "" {
+		out.PublicCert = &c.PublicCert
+	}
+	if c.Issuer != "" {
+		out.Iss = &c.Issuer
+	}
+	if c.Audience != "" {
+		out.Aud = &c.Audience
+	}
+	if c.SubjectClaim != "" {
+		out.SubjectClaim = &c.SubjectClaim
+	}
+	return out
+}
+
+func toOAPISessionConfig(c *management.SessionConfig) *oapi.SessionPolicyConfig {
+	out := &oapi.SessionPolicyConfig{}
+	if c.TTL > 0 {
+		seconds := int(c.TTL / time.Second)
+		out.TtlSeconds = &seconds
+	}
+	if c.Role != "" {
+		role := oapi.ProjectRole(c.Role)
+		out.Role = &role
+	}
+	return out
+}

--- a/internal/http/controllers/v1/management/accesspolicies_test.go
+++ b/internal/http/controllers/v1/management/accesspolicies_test.go
@@ -1,0 +1,86 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/lunogram/platform/internal/http/controllers/v1/management/oapi"
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCreateInput(t *testing.T) {
+	t.Parallel()
+
+	scope := func(s oapi.ApiKeyScope) *oapi.ApiKeyScope { return &s }
+	role := func(r oapi.ProjectRole) *oapi.ProjectRole { return &r }
+
+	t.Run("defaults role to support for secret keys", func(t *testing.T) {
+		in, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type:  oapi.AccessPolicyType("api_key"),
+			Name:  "backend",
+			Scope: scope("secret"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "support", in.Role)
+	})
+
+	t.Run("defaults public keys to the write-only client role", func(t *testing.T) {
+		in, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type:  oapi.AccessPolicyType("api_key"),
+			Name:  "web",
+			Scope: scope("public"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "client", in.Role)
+	})
+
+	t.Run("rejects a public key with a readable role", func(t *testing.T) {
+		_, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type:  oapi.AccessPolicyType("api_key"),
+			Name:  "web",
+			Scope: scope("public"),
+			Role:  role("editor"),
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a public key granted read access", func(t *testing.T) {
+		_, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type:  oapi.AccessPolicyType("api_key"),
+			Name:  "web",
+			Scope: scope("public"),
+			Grants: &[]oapi.PermissionGrant{
+				{Resource: "inbox", Verb: oapi.PermissionGrantVerb("read")},
+			},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("allows a public key with write-only grants", func(t *testing.T) {
+		in, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type:  oapi.AccessPolicyType("api_key"),
+			Name:  "web",
+			Scope: scope("public"),
+			Grants: &[]oapi.PermissionGrant{
+				{Resource: "events", Verb: oapi.PermissionGrantVerb("create")},
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, in.Grants, 1)
+	})
+
+	t.Run("maps trusted-issuer config", func(t *testing.T) {
+		in, err := buildCreateInput(oapi.CreateAccessPolicy{
+			Type: oapi.AccessPolicyType("trusted_issuer"),
+			Name: "idp",
+			IssuerConfig: &oapi.TrustedIssuerConfig{
+				JwksUrl: ptr.To("https://idp.example/jwks.json"),
+				Iss:     ptr.To("https://idp.example"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, in.IssuerConfig)
+		assert.Equal(t, "https://idp.example/jwks.json", in.IssuerConfig.JWKSURL)
+	})
+}

--- a/internal/http/controllers/v1/management/controller.go
+++ b/internal/http/controllers/v1/management/controller.go
@@ -42,6 +42,7 @@ func NewController(logger *zap.Logger, managementDB, usersDB, journeyDB *sqlx.DB
 		ProvidersController:        NewProvidersController(logger, managementDB, registry, engine, cfg.PublicBaseURL()),
 		SubscriptionsController:    NewSubscriptionsController(logger, managementDB, engine),
 		ApiKeysController:          NewApiKeysController(logger, managementDB, engine),
+		AccessPoliciesController:   NewAccessPoliciesController(logger, managementDB, engine),
 		EmailTemplatesController:   NewEmailTemplatesController(logger, webhookCaller, engine),
 		SenderIdentitiesController: NewSenderIdentitiesController(logger, managementDB, engine),
 		PushProvidersController:    NewPushProvidersController(logger, managementDB, registry, engine),
@@ -74,6 +75,7 @@ type Controller struct {
 	*SubscriptionsController
 	*AuthController
 	*ApiKeysController
+	*AccessPoliciesController
 	*ActionsController
 	*EmailTemplatesController
 	*SenderIdentitiesController

--- a/internal/http/controllers/v1/management/oapi/resources.yml
+++ b/internal/http/controllers/v1/management/oapi/resources.yml
@@ -4770,6 +4770,165 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/admin/projects/{projectID}/access-policies:
+    get:
+      summary: List access policies
+      description: Retrieves a paginated list of access policies for a project
+      operationId: listAccessPolicies
+      tags:
+        - Access Policies
+      security:
+        - HttpBearerAuth: []
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The project ID
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          $ref: "#/components/responses/AccessPolicyListResponse"
+        default:
+          $ref: "#/components/responses/Error"
+
+    post:
+      summary: Create access policy
+      description: Creates a new access policy for a project. For api_key policies the secret is returned only in this response.
+      operationId: createAccessPolicy
+      tags:
+        - Access Policies
+      security:
+        - HttpBearerAuth: []
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The project ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAccessPolicy"
+      responses:
+        "201":
+          description: Access policy created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessPolicy"
+        default:
+          $ref: "#/components/responses/Error"
+
+  /api/admin/projects/{projectID}/access-policies/{policyID}:
+    get:
+      summary: Get access policy by ID
+      description: Retrieves a specific access policy. The secret is never included.
+      operationId: getAccessPolicy
+      tags:
+        - Access Policies
+      security:
+        - HttpBearerAuth: []
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The project ID
+        - name: policyID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The access policy ID
+      responses:
+        "200":
+          description: Access policy retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessPolicy"
+        default:
+          $ref: "#/components/responses/Error"
+
+    patch:
+      summary: Update access policy
+      description: Updates an access policy's name, description, role or grants.
+      operationId: updateAccessPolicy
+      tags:
+        - Access Policies
+      security:
+        - HttpBearerAuth: []
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The project ID
+        - name: policyID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The access policy ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAccessPolicy"
+      responses:
+        "200":
+          description: Access policy updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessPolicy"
+        default:
+          $ref: "#/components/responses/Error"
+
+    delete:
+      summary: Delete access policy
+      description: Deletes an access policy, revoking access.
+      operationId: deleteAccessPolicy
+      tags:
+        - Access Policies
+      security:
+        - HttpBearerAuth: []
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The project ID
+        - name: policyID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The access policy ID
+      responses:
+        "204":
+          description: Access policy deleted successfully
+        default:
+          $ref: "#/components/responses/Error"
+
   /api/admin/projects/{projectID}/actions:
     get:
       summary: List actions
@@ -6275,6 +6434,22 @@ components:
                     type: array
                     items:
                       $ref: "#/components/schemas/ApiKey"
+
+    AccessPolicyListResponse:
+      description: Access policies retrieved successfully
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/PaginatedResponse"
+              - type: object
+                required:
+                  - results
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AccessPolicy"
 
     ActionListResponse:
       description: Actions retrieved successfully
@@ -9147,6 +9322,150 @@ components:
         description:
           type: string
           example: "Updated description"
+
+    AccessPolicyType:
+      type: string
+      enum: [api_key, trusted_issuer, session]
+      description: |
+        How an access policy authenticates a client. `api_key` is a
+        Lunogram-issued key; `trusted_issuer` validates external JWTs against a
+        configured JWKS/PEM; `session` mints short-lived user-scoped tokens.
+      example: api_key
+
+    PermissionGrant:
+      type: object
+      description: A single (resource, verb) entry in a custom permission set.
+      required:
+        - resource
+        - verb
+      properties:
+        resource:
+          type: string
+          example: inbox
+        verb:
+          type: string
+          enum: [read, create, update, delete]
+          example: read
+
+    TrustedIssuerConfig:
+      type: object
+      description: Verification settings for a trusted_issuer policy. Exactly one of jwks_url or public_cert is set.
+      properties:
+        jwks_url:
+          type: string
+          example: "https://acme.example/.well-known/jwks.json"
+        public_cert:
+          type: string
+          description: PEM-encoded public certificate (alternative to jwks_url).
+        iss:
+          type: string
+          example: "https://acme.example"
+        aud:
+          type: string
+          example: "lunogram"
+        subject_claim:
+          type: string
+          description: JWT claim carrying the external user id (defaults to "sub").
+          example: sub
+
+    SessionPolicyConfig:
+      type: object
+      description: Settings for a session policy.
+      properties:
+        ttl_seconds:
+          type: integer
+          description: Lifetime of minted session tokens, in seconds.
+          example: 900
+        role:
+          $ref: "#/components/schemas/ProjectRole"
+
+    AccessPolicy:
+      type: object
+      required:
+        - id
+        - project_id
+        - type
+        - name
+        - role
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        project_id:
+          type: string
+          format: uuid
+        type:
+          $ref: "#/components/schemas/AccessPolicyType"
+        name:
+          type: string
+          example: "Production key"
+        description:
+          type: string
+        scope:
+          $ref: "#/components/schemas/ApiKeyScope"
+        role:
+          $ref: "#/components/schemas/ProjectRole"
+        grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionGrant"
+        issuer_config:
+          $ref: "#/components/schemas/TrustedIssuerConfig"
+        session_config:
+          $ref: "#/components/schemas/SessionPolicyConfig"
+        secret:
+          type: string
+          description: |
+            The full secret value. Returned only once, in the response to
+            creating an api_key policy, and never again.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateAccessPolicy:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          $ref: "#/components/schemas/AccessPolicyType"
+        name:
+          type: string
+        description:
+          type: string
+        scope:
+          $ref: "#/components/schemas/ApiKeyScope"
+        role:
+          $ref: "#/components/schemas/ProjectRole"
+        grants:
+          type: array
+          description: Custom permission set. When set, takes precedence over the role preset.
+          items:
+            $ref: "#/components/schemas/PermissionGrant"
+        issuer_config:
+          $ref: "#/components/schemas/TrustedIssuerConfig"
+        session_config:
+          $ref: "#/components/schemas/SessionPolicyConfig"
+
+    UpdateAccessPolicy:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        role:
+          $ref: "#/components/schemas/ProjectRole"
+        grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionGrant"
 
     ClientEvent:
       type: object

--- a/internal/http/controllers/v1/management/oapi/resources_gen.go
+++ b/internal/http/controllers/v1/management/oapi/resources_gen.go
@@ -25,6 +25,27 @@ const (
 	HttpBearerAuthScopes httpBearerAuthContextKey = "HttpBearerAuth.Scopes"
 )
 
+// Defines values for AccessPolicyType.
+const (
+	AccessPolicyTypeApiKey        AccessPolicyType = "api_key"
+	AccessPolicyTypeSession       AccessPolicyType = "session"
+	AccessPolicyTypeTrustedIssuer AccessPolicyType = "trusted_issuer"
+)
+
+// Valid indicates whether the value is a known member of the AccessPolicyType enum.
+func (e AccessPolicyType) Valid() bool {
+	switch e {
+	case AccessPolicyTypeApiKey:
+		return true
+	case AccessPolicyTypeSession:
+		return true
+	case AccessPolicyTypeTrustedIssuer:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ApiKeyScope.
 const (
 	Public ApiKeyScope = "public"
@@ -331,6 +352,30 @@ func (e OrganizationRole) Valid() bool {
 	}
 }
 
+// Defines values for PermissionGrantVerb.
+const (
+	PermissionGrantVerbCreate PermissionGrantVerb = "create"
+	PermissionGrantVerbDelete PermissionGrantVerb = "delete"
+	PermissionGrantVerbRead   PermissionGrantVerb = "read"
+	PermissionGrantVerbUpdate PermissionGrantVerb = "update"
+)
+
+// Valid indicates whether the value is a known member of the PermissionGrantVerb enum.
+func (e PermissionGrantVerb) Valid() bool {
+	switch e {
+	case PermissionGrantVerbCreate:
+		return true
+	case PermissionGrantVerbDelete:
+		return true
+	case PermissionGrantVerbRead:
+		return true
+	case PermissionGrantVerbUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ProjectPushProviderPlatform.
 const (
 	ProjectPushProviderPlatformAndroid ProjectPushProviderPlatform = "android"
@@ -595,6 +640,43 @@ func (e AuthWebhookParamsDriver) Valid() bool {
 	}
 }
 
+// AccessPolicy defines model for AccessPolicy.
+type AccessPolicy struct {
+	CreatedAt   time.Time          `json:"created_at"`
+	Description *string            `json:"description,omitempty"`
+	Grants      *[]PermissionGrant `json:"grants,omitempty"`
+	Id          openapi_types.UUID `json:"id"`
+
+	// IssuerConfig Verification settings for a trusted_issuer policy. Exactly one of jwks_url or public_cert is set.
+	IssuerConfig *TrustedIssuerConfig `json:"issuer_config,omitempty"`
+	Name         string               `json:"name"`
+	ProjectId    openapi_types.UUID   `json:"project_id"`
+
+	// Role Role within a project
+	Role ProjectRole `json:"role"`
+
+	// Scope API key scope - public keys are safe to expose in client-side code
+	Scope *ApiKeyScope `json:"scope,omitempty"`
+
+	// Secret The full secret value. Returned only once, in the response to
+	// creating an api_key policy, and never again.
+	Secret *string `json:"secret,omitempty"`
+
+	// SessionConfig Settings for a session policy.
+	SessionConfig *SessionPolicyConfig `json:"session_config,omitempty"`
+
+	// Type How an access policy authenticates a client. `api_key` is a
+	// Lunogram-issued key; `trusted_issuer` validates external JWTs against a
+	// configured JWKS/PEM; `session` mints short-lived user-scoped tokens.
+	Type      AccessPolicyType `json:"type"`
+	UpdatedAt time.Time        `json:"updated_at"`
+}
+
+// AccessPolicyType How an access policy authenticates a client. `api_key` is a
+// Lunogram-issued key; `trusted_issuer` validates external JWTs against a
+// configured JWKS/PEM; `session` mints short-lived user-scoped tokens.
+type AccessPolicyType string
+
 // Action defines model for Action.
 type Action struct {
 	// Config Action configuration (varies by type)
@@ -820,6 +902,32 @@ type CampaignVariable struct {
 
 // Channel Communication channel type
 type Channel string
+
+// CreateAccessPolicy defines model for CreateAccessPolicy.
+type CreateAccessPolicy struct {
+	Description *string `json:"description,omitempty"`
+
+	// Grants Custom permission set. When set, takes precedence over the role preset.
+	Grants *[]PermissionGrant `json:"grants,omitempty"`
+
+	// IssuerConfig Verification settings for a trusted_issuer policy. Exactly one of jwks_url or public_cert is set.
+	IssuerConfig *TrustedIssuerConfig `json:"issuer_config,omitempty"`
+	Name         string               `json:"name"`
+
+	// Role Role within a project
+	Role *ProjectRole `json:"role,omitempty"`
+
+	// Scope API key scope - public keys are safe to expose in client-side code
+	Scope *ApiKeyScope `json:"scope,omitempty"`
+
+	// SessionConfig Settings for a session policy.
+	SessionConfig *SessionPolicyConfig `json:"session_config,omitempty"`
+
+	// Type How an access policy authenticates a client. `api_key` is a
+	// Lunogram-issued key; `trusted_issuer` validates external JWTs against a
+	// configured JWKS/PEM; `session` mints short-lived user-scoped tokens.
+	Type AccessPolicyType `json:"type"`
+}
 
 // CreateAction defines model for CreateAction.
 type CreateAction struct {
@@ -1484,6 +1592,15 @@ type PaginatedResponse struct {
 	Total int `json:"total"`
 }
 
+// PermissionGrant A single (resource, verb) entry in a custom permission set.
+type PermissionGrant struct {
+	Resource string              `json:"resource"`
+	Verb     PermissionGrantVerb `json:"verb"`
+}
+
+// PermissionGrantVerb defines model for PermissionGrant.Verb.
+type PermissionGrantVerb string
+
 // Problem defines model for Problem.
 type Problem struct {
 	// Detail A human readable explanation specific to this occurrence of the problem that is helpful to locate the problem and give advice on how to proceed. Written in English and readable for engineers, usually not suited for non technical stakeholders and not localized.
@@ -1726,6 +1843,15 @@ type SenderIdentity struct {
 // SenderIdentityChannel Channel type (email or sms)
 type SenderIdentityChannel string
 
+// SessionPolicyConfig Settings for a session policy.
+type SessionPolicyConfig struct {
+	// Role Role within a project
+	Role *ProjectRole `json:"role,omitempty"`
+
+	// TtlSeconds Lifetime of minted session tokens, in seconds.
+	TtlSeconds *int `json:"ttl_seconds,omitempty"`
+}
+
 // SmsProviderData defines model for SmsProviderData.
 type SmsProviderData = map[string]interface{}
 
@@ -1809,6 +1935,29 @@ type TestActionResult struct {
 
 	// StatusCode Status code returned by the validation (e.g. 200 for success, 400/401/500 for errors)
 	StatusCode int `json:"status_code"`
+}
+
+// TrustedIssuerConfig Verification settings for a trusted_issuer policy. Exactly one of jwks_url or public_cert is set.
+type TrustedIssuerConfig struct {
+	Aud     *string `json:"aud,omitempty"`
+	Iss     *string `json:"iss,omitempty"`
+	JwksUrl *string `json:"jwks_url,omitempty"`
+
+	// PublicCert PEM-encoded public certificate (alternative to jwks_url).
+	PublicCert *string `json:"public_cert,omitempty"`
+
+	// SubjectClaim JWT claim carrying the external user id (defaults to "sub").
+	SubjectClaim *string `json:"subject_claim,omitempty"`
+}
+
+// UpdateAccessPolicy defines model for UpdateAccessPolicy.
+type UpdateAccessPolicy struct {
+	Description *string            `json:"description,omitempty"`
+	Grants      *[]PermissionGrant `json:"grants,omitempty"`
+	Name        *string            `json:"name,omitempty"`
+
+	// Role Role within a project
+	Role *ProjectRole `json:"role,omitempty"`
 }
 
 // UpdateAction defines model for UpdateAction.
@@ -2206,6 +2355,19 @@ type Offset = PaginationOffset
 // Search defines model for Search.
 type Search = PaginationSearch
 
+// AccessPolicyListResponse defines model for AccessPolicyListResponse.
+type AccessPolicyListResponse struct {
+	// Limit Maximum number of items returned
+	Limit int `json:"limit"`
+
+	// Offset Number of items skipped
+	Offset  int            `json:"offset"`
+	Results []AccessPolicy `json:"results"`
+
+	// Total Total number of items matching the filters
+	Total int `json:"total"`
+}
+
 // ActionListResponse defines model for ActionListResponse.
 type ActionListResponse struct {
 	// Limit Maximum number of items returned
@@ -2375,6 +2537,15 @@ type ListProjectsParams struct {
 
 	// Search Search query string
 	Search *Search `form:"search,omitempty" json:"search,omitempty"`
+}
+
+// ListAccessPoliciesParams defines parameters for ListAccessPolicies.
+type ListAccessPoliciesParams struct {
+	// Limit Maximum number of items to return
+	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of items to skip
+	Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
 // ListActionsParams defines parameters for ListActions.
@@ -2811,6 +2982,12 @@ type CreateProjectJSONRequestBody = CreateProject
 // UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
 type UpdateProjectJSONRequestBody = UpdateProject
 
+// CreateAccessPolicyJSONRequestBody defines body for CreateAccessPolicy for application/json ContentType.
+type CreateAccessPolicyJSONRequestBody = CreateAccessPolicy
+
+// UpdateAccessPolicyJSONRequestBody defines body for UpdateAccessPolicy for application/json ContentType.
+type UpdateAccessPolicyJSONRequestBody = UpdateAccessPolicy
+
 // CreateActionJSONRequestBody defines body for CreateAction for application/json ContentType.
 type CreateActionJSONRequestBody = CreateAction
 
@@ -3067,6 +3244,25 @@ type ClientInterface interface {
 	UpdateProjectWithBody(ctx context.Context, projectID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateProject(ctx context.Context, projectID openapi_types.UUID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAccessPolicies request
+	ListAccessPolicies(ctx context.Context, projectID openapi_types.UUID, params *ListAccessPoliciesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateAccessPolicyWithBody request with any body
+	CreateAccessPolicyWithBody(ctx context.Context, projectID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateAccessPolicy(ctx context.Context, projectID openapi_types.UUID, body CreateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAccessPolicy request
+	DeleteAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAccessPolicy request
+	GetAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAccessPolicyWithBody request with any body
+	UpdateAccessPolicyWithBody(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, body UpdateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListActions request
 	ListActions(ctx context.Context, projectID openapi_types.UUID, params *ListActionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3755,6 +3951,90 @@ func (c *Client) UpdateProjectWithBody(ctx context.Context, projectID openapi_ty
 
 func (c *Client) UpdateProject(ctx context.Context, projectID openapi_types.UUID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateProjectRequest(c.Server, projectID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAccessPolicies(ctx context.Context, projectID openapi_types.UUID, params *ListAccessPoliciesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAccessPoliciesRequest(c.Server, projectID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAccessPolicyWithBody(ctx context.Context, projectID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAccessPolicyRequestWithBody(c.Server, projectID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAccessPolicy(ctx context.Context, projectID openapi_types.UUID, body CreateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAccessPolicyRequest(c.Server, projectID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAccessPolicyRequest(c.Server, projectID, policyID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAccessPolicyRequest(c.Server, projectID, policyID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAccessPolicyWithBody(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAccessPolicyRequestWithBody(c.Server, projectID, policyID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAccessPolicy(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, body UpdateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAccessPolicyRequest(c.Server, projectID, policyID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6610,6 +6890,262 @@ func NewUpdateProjectRequestWithBody(server string, projectID openapi_types.UUID
 	}
 
 	operationPath := fmt.Sprintf("/api/admin/projects/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListAccessPoliciesRequest generates requests for ListAccessPolicies
+func NewListAccessPoliciesRequest(server string, projectID openapi_types.UUID, params *ListAccessPoliciesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectID", projectID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/admin/projects/%s/access-policies", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateAccessPolicyRequest calls the generic CreateAccessPolicy builder with application/json body
+func NewCreateAccessPolicyRequest(server string, projectID openapi_types.UUID, body CreateAccessPolicyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateAccessPolicyRequestWithBody(server, projectID, "application/json", bodyReader)
+}
+
+// NewCreateAccessPolicyRequestWithBody generates requests for CreateAccessPolicy with any type of body
+func NewCreateAccessPolicyRequestWithBody(server string, projectID openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectID", projectID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/admin/projects/%s/access-policies", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAccessPolicyRequest generates requests for DeleteAccessPolicy
+func NewDeleteAccessPolicyRequest(server string, projectID openapi_types.UUID, policyID openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectID", projectID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "policyID", policyID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/admin/projects/%s/access-policies/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAccessPolicyRequest generates requests for GetAccessPolicy
+func NewGetAccessPolicyRequest(server string, projectID openapi_types.UUID, policyID openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectID", projectID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "policyID", policyID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/admin/projects/%s/access-policies/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAccessPolicyRequest calls the generic UpdateAccessPolicy builder with application/json body
+func NewUpdateAccessPolicyRequest(server string, projectID openapi_types.UUID, policyID openapi_types.UUID, body UpdateAccessPolicyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAccessPolicyRequestWithBody(server, projectID, policyID, "application/json", bodyReader)
+}
+
+// NewUpdateAccessPolicyRequestWithBody generates requests for UpdateAccessPolicy with any type of body
+func NewUpdateAccessPolicyRequestWithBody(server string, projectID openapi_types.UUID, policyID openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectID", projectID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "policyID", policyID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/admin/projects/%s/access-policies/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -15726,6 +16262,25 @@ type ClientWithResponsesInterface interface {
 
 	UpdateProjectWithResponse(ctx context.Context, projectID openapi_types.UUID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
 
+	// ListAccessPoliciesWithResponse request
+	ListAccessPoliciesWithResponse(ctx context.Context, projectID openapi_types.UUID, params *ListAccessPoliciesParams, reqEditors ...RequestEditorFn) (*ListAccessPoliciesResponse, error)
+
+	// CreateAccessPolicyWithBodyWithResponse request with any body
+	CreateAccessPolicyWithBodyWithResponse(ctx context.Context, projectID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAccessPolicyResponse, error)
+
+	CreateAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, body CreateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAccessPolicyResponse, error)
+
+	// DeleteAccessPolicyWithResponse request
+	DeleteAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteAccessPolicyResponse, error)
+
+	// GetAccessPolicyWithResponse request
+	GetAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetAccessPolicyResponse, error)
+
+	// UpdateAccessPolicyWithBodyWithResponse request with any body
+	UpdateAccessPolicyWithBodyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAccessPolicyResponse, error)
+
+	UpdateAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, body UpdateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAccessPolicyResponse, error)
+
 	// ListActionsWithResponse request
 	ListActionsWithResponse(ctx context.Context, projectID openapi_types.UUID, params *ListActionsParams, reqEditors ...RequestEditorFn) (*ListActionsResponse, error)
 
@@ -16506,6 +17061,160 @@ func (r UpdateProjectResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateProjectResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAccessPoliciesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AccessPolicyListResponse
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAccessPoliciesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAccessPoliciesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAccessPoliciesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateAccessPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *AccessPolicy
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateAccessPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateAccessPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateAccessPolicyResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteAccessPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAccessPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAccessPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteAccessPolicyResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetAccessPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AccessPolicy
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAccessPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAccessPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetAccessPolicyResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAccessPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AccessPolicy
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAccessPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAccessPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAccessPolicyResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -21746,6 +22455,67 @@ func (c *ClientWithResponses) UpdateProjectWithResponse(ctx context.Context, pro
 	return ParseUpdateProjectResponse(rsp)
 }
 
+// ListAccessPoliciesWithResponse request returning *ListAccessPoliciesResponse
+func (c *ClientWithResponses) ListAccessPoliciesWithResponse(ctx context.Context, projectID openapi_types.UUID, params *ListAccessPoliciesParams, reqEditors ...RequestEditorFn) (*ListAccessPoliciesResponse, error) {
+	rsp, err := c.ListAccessPolicies(ctx, projectID, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAccessPoliciesResponse(rsp)
+}
+
+// CreateAccessPolicyWithBodyWithResponse request with arbitrary body returning *CreateAccessPolicyResponse
+func (c *ClientWithResponses) CreateAccessPolicyWithBodyWithResponse(ctx context.Context, projectID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAccessPolicyResponse, error) {
+	rsp, err := c.CreateAccessPolicyWithBody(ctx, projectID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAccessPolicyResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, body CreateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAccessPolicyResponse, error) {
+	rsp, err := c.CreateAccessPolicy(ctx, projectID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAccessPolicyResponse(rsp)
+}
+
+// DeleteAccessPolicyWithResponse request returning *DeleteAccessPolicyResponse
+func (c *ClientWithResponses) DeleteAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteAccessPolicyResponse, error) {
+	rsp, err := c.DeleteAccessPolicy(ctx, projectID, policyID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAccessPolicyResponse(rsp)
+}
+
+// GetAccessPolicyWithResponse request returning *GetAccessPolicyResponse
+func (c *ClientWithResponses) GetAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetAccessPolicyResponse, error) {
+	rsp, err := c.GetAccessPolicy(ctx, projectID, policyID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAccessPolicyResponse(rsp)
+}
+
+// UpdateAccessPolicyWithBodyWithResponse request with arbitrary body returning *UpdateAccessPolicyResponse
+func (c *ClientWithResponses) UpdateAccessPolicyWithBodyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAccessPolicyResponse, error) {
+	rsp, err := c.UpdateAccessPolicyWithBody(ctx, projectID, policyID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAccessPolicyResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAccessPolicyWithResponse(ctx context.Context, projectID openapi_types.UUID, policyID openapi_types.UUID, body UpdateAccessPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAccessPolicyResponse, error) {
+	rsp, err := c.UpdateAccessPolicy(ctx, projectID, policyID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAccessPolicyResponse(rsp)
+}
+
 // ListActionsWithResponse request returning *ListActionsResponse
 func (c *ClientWithResponses) ListActionsWithResponse(ctx context.Context, projectID openapi_types.UUID, params *ListActionsParams, reqEditors ...RequestEditorFn) (*ListActionsResponse, error) {
 	rsp, err := c.ListActions(ctx, projectID, params, reqEditors...)
@@ -23822,6 +24592,164 @@ func ParseUpdateProjectResponse(rsp *http.Response) (*UpdateProjectResponse, err
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Project
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAccessPoliciesResponse parses an HTTP response from a ListAccessPoliciesWithResponse call
+func ParseListAccessPoliciesResponse(rsp *http.Response) (*ListAccessPoliciesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAccessPoliciesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AccessPolicyListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateAccessPolicyResponse parses an HTTP response from a CreateAccessPolicyWithResponse call
+func ParseCreateAccessPolicyResponse(rsp *http.Response) (*CreateAccessPolicyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateAccessPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest AccessPolicy
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAccessPolicyResponse parses an HTTP response from a DeleteAccessPolicyWithResponse call
+func ParseDeleteAccessPolicyResponse(rsp *http.Response) (*DeleteAccessPolicyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAccessPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAccessPolicyResponse parses an HTTP response from a GetAccessPolicyWithResponse call
+func ParseGetAccessPolicyResponse(rsp *http.Response) (*GetAccessPolicyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAccessPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AccessPolicy
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAccessPolicyResponse parses an HTTP response from a UpdateAccessPolicyWithResponse call
+func ParseUpdateAccessPolicyResponse(rsp *http.Response) (*UpdateAccessPolicyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAccessPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AccessPolicy
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -29091,6 +30019,21 @@ type ServerInterface interface {
 	// Update project
 	// (PATCH /api/admin/projects/{projectID})
 	UpdateProject(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID)
+	// List access policies
+	// (GET /api/admin/projects/{projectID}/access-policies)
+	ListAccessPolicies(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, params ListAccessPoliciesParams)
+	// Create access policy
+	// (POST /api/admin/projects/{projectID}/access-policies)
+	CreateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID)
+	// Delete access policy
+	// (DELETE /api/admin/projects/{projectID}/access-policies/{policyID})
+	DeleteAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID)
+	// Get access policy by ID
+	// (GET /api/admin/projects/{projectID}/access-policies/{policyID})
+	GetAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID)
+	// Update access policy
+	// (PATCH /api/admin/projects/{projectID}/access-policies/{policyID})
+	UpdateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID)
 	// List actions
 	// (GET /api/admin/projects/{projectID}/actions)
 	ListActions(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, params ListActionsParams)
@@ -29628,6 +30571,36 @@ func (_ Unimplemented) GetProject(w http.ResponseWriter, r *http.Request, projec
 // Update project
 // (PATCH /api/admin/projects/{projectID})
 func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List access policies
+// (GET /api/admin/projects/{projectID}/access-policies)
+func (_ Unimplemented) ListAccessPolicies(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, params ListAccessPoliciesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create access policy
+// (POST /api/admin/projects/{projectID}/access-policies)
+func (_ Unimplemented) CreateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete access policy
+// (DELETE /api/admin/projects/{projectID}/access-policies/{policyID})
+func (_ Unimplemented) DeleteAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get access policy by ID
+// (GET /api/admin/projects/{projectID}/access-policies/{policyID})
+func (_ Unimplemented) GetAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update access policy
+// (PATCH /api/admin/projects/{projectID}/access-policies/{policyID})
+func (_ Unimplemented) UpdateAccessPolicy(w http.ResponseWriter, r *http.Request, projectID openapi_types.UUID, policyID openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -30828,6 +31801,222 @@ func (siw *ServerInterfaceWrapper) UpdateProject(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateProject(w, r, projectID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAccessPolicies operation middleware
+func (siw *ServerInterfaceWrapper) ListAccessPolicies(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectID" -------------
+	var projectID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectID", chi.URLParam(r, "projectID"), &projectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, HttpBearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListAccessPoliciesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", r.URL.Query(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "offset"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAccessPolicies(w, r, projectID, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateAccessPolicy operation middleware
+func (siw *ServerInterfaceWrapper) CreateAccessPolicy(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectID" -------------
+	var projectID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectID", chi.URLParam(r, "projectID"), &projectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, HttpBearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateAccessPolicy(w, r, projectID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAccessPolicy operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAccessPolicy(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectID" -------------
+	var projectID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectID", chi.URLParam(r, "projectID"), &projectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectID", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "policyID" -------------
+	var policyID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyID", chi.URLParam(r, "policyID"), &policyID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "policyID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, HttpBearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAccessPolicy(w, r, projectID, policyID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAccessPolicy operation middleware
+func (siw *ServerInterfaceWrapper) GetAccessPolicy(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectID" -------------
+	var projectID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectID", chi.URLParam(r, "projectID"), &projectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectID", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "policyID" -------------
+	var policyID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyID", chi.URLParam(r, "policyID"), &policyID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "policyID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, HttpBearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAccessPolicy(w, r, projectID, policyID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAccessPolicy operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAccessPolicy(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectID" -------------
+	var projectID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectID", chi.URLParam(r, "projectID"), &projectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectID", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "policyID" -------------
+	var policyID openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyID", chi.URLParam(r, "policyID"), &policyID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "policyID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, HttpBearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAccessPolicy(w, r, projectID, policyID)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -38979,6 +40168,21 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Patch(options.BaseURL+"/api/admin/projects/{projectID}", wrapper.UpdateProject)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/admin/projects/{projectID}/access-policies", wrapper.ListAccessPolicies)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/admin/projects/{projectID}/access-policies", wrapper.CreateAccessPolicy)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/api/admin/projects/{projectID}/access-policies/{policyID}", wrapper.DeleteAccessPolicy)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/admin/projects/{projectID}/access-policies/{policyID}", wrapper.GetAccessPolicy)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/admin/projects/{projectID}/access-policies/{policyID}", wrapper.UpdateAccessPolicy)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/admin/projects/{projectID}/actions", wrapper.ListActions)

--- a/internal/http/problem/problem.go
+++ b/internal/http/problem/problem.go
@@ -28,6 +28,9 @@ var ErrForbidden = ErrorFunc(WithStatus(NewError("forbidden", "you do not have p
 // ErrConflict is thrown whenever a resource conflicts with an existing one.
 var ErrConflict = ErrorFunc(WithStatus(NewError("conflict", "the resource already exists"), http.StatusConflict))
 
+// ErrTooManyRequests is thrown when a client exceeds its rate limit.
+var ErrTooManyRequests = ErrorFunc(WithStatus(NewError("too many requests", "the rate limit for this request has been exceeded"), http.StatusTooManyRequests))
+
 // NewError creates a new error with the given title and description.
 func NewError(title, description string) error {
 	return &withDescription{

--- a/internal/rbac/access/access.go
+++ b/internal/rbac/access/access.go
@@ -78,6 +78,56 @@ func UpdateApiKeyRole(ctx context.Context, engine *rbac.Engine, keyID, projectID
 	return ProvisionApiKey(ctx, engine, keyID, projectID, newRole)
 }
 
+// Grant is a single (resource, verb) entry in a custom permission set. It maps
+// to one direct relation tuple written onto the project-scoped resource object.
+//
+//	{Resource: "inbox", Verb: rbac.Read}  →  user:<policy-id> read inbox:<project-id>
+type Grant struct {
+	Resource string
+	Verb     rbac.Permission
+}
+
+// PolicyGrantTuples returns the tuples that grant an access policy a custom
+// permission set. Each grant becomes a direct relation tuple on the
+// project-scoped resource object. The policyID is the access policy's UUID,
+// used as the RBAC user identity so that checks via [rbac.Actor.UserKey]
+// resolve against these grants.
+//
+// Use this for policies that carry an explicit scope rather than one of the
+// four role presets (see [ApiKeyRoleTuples]).
+func PolicyGrantTuples(policyID, projectID uuid.UUID, grants []Grant) []rbac.Tuple {
+	user := "user:" + policyID.String()
+	tuples := make([]rbac.Tuple, 0, len(grants))
+	for _, g := range grants {
+		tuples = append(tuples, rbac.Tuple{
+			User:     user,
+			Relation: string(g.Verb),
+			Object:   rbac.ProjectResourceScope(g.Resource, projectID),
+		})
+	}
+	return tuples
+}
+
+// ProvisionPolicyGrants writes the custom permission-set tuples for an access
+// policy. Call this when a policy with a custom scope is created. It is a no-op
+// when grants is empty.
+func ProvisionPolicyGrants(ctx context.Context, engine *rbac.Engine, policyID, projectID uuid.UUID, grants []Grant) error {
+	if err := engine.WriteTuples(ctx, PolicyGrantTuples(policyID, projectID, grants)); err != nil {
+		return fmt.Errorf("access: failed to provision grants for policy %s: %w", policyID, err)
+	}
+	return nil
+}
+
+// DeprovisionPolicyGrants removes the custom permission-set tuples created by
+// [ProvisionPolicyGrants]. Call this when a policy is deleted, or before
+// rewriting its scope. It is a no-op when grants is empty.
+func DeprovisionPolicyGrants(ctx context.Context, engine *rbac.Engine, policyID, projectID uuid.UUID, grants []Grant) error {
+	if err := engine.DeleteTuples(ctx, PolicyGrantTuples(policyID, projectID, grants)); err != nil {
+		return fmt.Errorf("access: failed to deprovision grants for policy %s: %w", policyID, err)
+	}
+	return nil
+}
+
 // ProjectTuples returns the tuples that link a project to its parent
 // organization and connect every resource type to the project. These tuples
 // are required for project-scoped permission checks to resolve correctly

--- a/internal/rbac/access/grants_test.go
+++ b/internal/rbac/access/grants_test.go
@@ -1,0 +1,78 @@
+package access
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/rbac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyGrantTuples(t *testing.T) {
+	t.Parallel()
+
+	policyID := uuid.New()
+	projectID := uuid.New()
+
+	grants := []Grant{
+		{Resource: "inbox", Verb: rbac.Read},
+		{Resource: "users", Verb: rbac.Read},
+	}
+
+	expected := []rbac.Tuple{
+		{User: "user:" + policyID.String(), Relation: "read", Object: "inbox:" + projectID.String()},
+		{User: "user:" + policyID.String(), Relation: "read", Object: "users:" + projectID.String()},
+	}
+
+	assert.Equal(t, expected, PolicyGrantTuples(policyID, projectID, grants))
+}
+
+func TestPolicyGrantTuplesEmpty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, PolicyGrantTuples(uuid.New(), uuid.New(), nil))
+}
+
+// TestProvisionPolicyGrants verifies that a custom permission set resolves
+// through the direct-grant path independently of the four role presets: only
+// the exact (resource, verb) pairs granted are allowed, and deprovisioning
+// removes them.
+func TestProvisionPolicyGrants(t *testing.T) {
+	t.Parallel()
+
+	engine := rbac.NewTestEngine(t)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	policyID := uuid.New()
+
+	// A custom read-only scope on inbox + users only — no role preset, and no
+	// project resource tuples written: the grants must resolve on their own.
+	grants := []Grant{
+		{Resource: "inbox", Verb: rbac.Read},
+		{Resource: "users", Verb: rbac.Read},
+	}
+	require.NoError(t, ProvisionPolicyGrants(ctx, engine, policyID, projectID, grants))
+
+	actor := rbac.NewActor(rbac.ActorAPIKey, policyID.String(),
+		rbac.WithOrganizationID(orgID),
+		rbac.WithProjectID(projectID),
+	)
+	actorCtx := rbac.WithActor(ctx, actor)
+
+	// Granted: read on inbox and users.
+	assert.NoError(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.NoError(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("users", projectID)))
+
+	// Not granted: write verbs on the same resources, or read on others.
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Create, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Update, rbac.ProjectResourceScope("users", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("campaigns", projectID)))
+
+	// Deprovisioning removes the grants.
+	require.NoError(t, DeprovisionPolicyGrants(ctx, engine, policyID, projectID, grants))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("inbox", projectID)))
+	assert.Error(t, engine.Allowed(actorCtx, rbac.Read, rbac.ProjectResourceScope("users", projectID)))
+}

--- a/internal/rbac/model.go
+++ b/internal/rbac/model.go
@@ -109,6 +109,23 @@ func union(children ...*openfgav1.Userset) *openfgav1.Userset {
 //
 // This follows the Google Zanzibar pattern where each resource type inherits
 // permissions from its parent container.
+//
+// # Custom permission sets
+//
+// Each resource CRUD relation is the union of a direct assignment and the
+// project-role path:
+//
+//	read: this OR project.<role-required-for-read>
+//
+// The project-role path expresses the four role presets (support/client/editor/
+// admin). The direct assignment lets an access policy be granted an explicit,
+// arbitrary scope by writing a tuple straight onto the resource, e.g.
+//
+//	user:<policy-id> → read → inbox:<project-id>
+//
+// This is how access policies carry a custom permission set (resource + verb
+// pairs) without being pinned to one of the four presets. See the access
+// package for the tuple-building helpers.
 func Model() []*openfgav1.TypeDefinition {
 	types := []*openfgav1.TypeDefinition{
 		{Type: "user"},
@@ -194,14 +211,21 @@ func Model() []*openfgav1.TypeDefinition {
 			Relations: map[string]*openfgav1.Userset{
 				"project": direct,
 
-				"read":   ttu("project", r.read),
-				"create": ttu("project", r.create),
-				"update": ttu("project", r.update),
-				"delete": ttu("project", r.delete),
+				// Each CRUD relation is the union of a direct grant (a custom
+				// per-policy scope written straight onto the resource) and the
+				// project-role preset path.
+				"read":   union(direct, ttu("project", r.read)),
+				"create": union(direct, ttu("project", r.create)),
+				"update": union(direct, ttu("project", r.update)),
+				"delete": union(direct, ttu("project", r.delete)),
 			},
 			Metadata: &openfgav1.Metadata{
 				Relations: map[string]*openfgav1.RelationMetadata{
 					"project": directlyRelated(typeRef("project")),
+					"read":    directlyRelated(typeRef("user")),
+					"create":  directlyRelated(typeRef("user")),
+					"update":  directlyRelated(typeRef("user")),
+					"delete":  directlyRelated(typeRef("user")),
 				},
 			},
 		})

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -10,8 +10,9 @@ import (
 type ActorType string
 
 const (
-	ActorAdmin  ActorType = "admin"
-	ActorAPIKey ActorType = "api_key"
+	ActorAdmin   ActorType = "admin"
+	ActorAPIKey  ActorType = "api_key"
+	ActorEndUser ActorType = "end_user"
 )
 
 const (
@@ -35,6 +36,17 @@ type Actor struct {
 	ID             string
 	OrganizationID uuid.UUID
 	ProjectID      uuid.UUID
+
+	// SubjectID is the resolved internal Lunogram user (subject) id for
+	// end-user actors ([ActorEndUser]). It is the zero UUID for admins and API
+	// keys.
+	//
+	// Authorization is always decided in OpenFGA against the policy identity
+	// ([Actor.UserKey]); SubjectID never participates in the permission check.
+	// It exists so handlers can scope queries to the verified user's own rows
+	// (e.g. WHERE user_id = SubjectID) once the policy has authorized the
+	// resource and verb.
+	SubjectID uuid.UUID
 }
 
 // ActorOption configures optional fields on an [Actor].
@@ -51,6 +63,15 @@ func WithOrganizationID(id uuid.UUID) ActorOption {
 func WithProjectID(id uuid.UUID) ActorOption {
 	return func(a *Actor) {
 		a.ProjectID = id
+	}
+}
+
+// WithSubjectID sets the resolved internal user (subject) id on the actor. Use
+// this for end-user actors so handlers can scope queries to the verified user's
+// own rows. See [Actor.SubjectID].
+func WithSubjectID(id uuid.UUID) ActorOption {
+	return func(a *Actor) {
+		a.SubjectID = id
 	}
 }
 

--- a/internal/store/management/accesspolicies.go
+++ b/internal/store/management/accesspolicies.go
@@ -1,0 +1,290 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/store"
+)
+
+// PolicyType identifies how an access policy authenticates a client. The API
+// key is the original type; trusted-issuer (JWKS / PEM) and short-term session
+// policies extend the model.
+type PolicyType string
+
+const (
+	PolicyTypeAPIKey        PolicyType = "api_key"
+	PolicyTypeTrustedIssuer PolicyType = "trusted_issuer"
+	PolicyTypeSession       PolicyType = "session"
+)
+
+// Grant is one (resource, verb) entry in a policy's custom permission set. It
+// mirrors access.Grant and is persisted in the access_policies.grants JSONB
+// column. An empty set means the policy uses its role preset instead.
+type Grant struct {
+	Resource string `json:"resource"`
+	Verb     string `json:"verb"`
+}
+
+// IssuerConfig holds the trusted-issuer verification settings for a
+// PolicyTypeTrustedIssuer policy. Exactly one of JWKSURL or PublicCert is set.
+type IssuerConfig struct {
+	JWKSURL      string `json:"jwks_url,omitempty"`
+	PublicCert   string `json:"public_cert,omitempty"`
+	Issuer       string `json:"iss,omitempty"`
+	Audience     string `json:"aud,omitempty"`
+	SubjectClaim string `json:"subject_claim,omitempty"`
+}
+
+// SessionConfig holds the short-term session-signing settings for a
+// PolicyTypeSession policy.
+type SessionConfig struct {
+	TTL  time.Duration `json:"ttl,omitempty"`
+	Role string        `json:"role,omitempty"`
+}
+
+// AccessPolicy is a project-scoped configuration of how a client authenticates
+// to the API. Type-specific fields (Secret, IssuerConfig, SessionConfig) are
+// populated according to Type.
+type AccessPolicy struct {
+	ID          uuid.UUID
+	ProjectID   uuid.UUID
+	Type        PolicyType
+	Name        string
+	Description *string
+	Scope       *string
+	Role        string
+
+	// Secret is the raw key value for api_key policies. It is nil for policy
+	// types that carry no Lunogram-held secret (e.g. trusted_issuer).
+	Secret *string
+
+	// Grants is the custom permission set. Nil/empty means the policy resolves
+	// through its Role preset.
+	Grants        []Grant
+	IssuerConfig  *IssuerConfig
+	SessionConfig *SessionConfig
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// accessPolicyRow mirrors the access_policies table for scanning. JSONB columns
+// are read as raw bytes and decoded into the typed [AccessPolicy] fields.
+type accessPolicyRow struct {
+	ID            uuid.UUID `db:"id"`
+	ProjectID     uuid.UUID `db:"project_id"`
+	Type          string    `db:"type"`
+	Value         *string   `db:"value"`
+	Scope         *string   `db:"scope"`
+	Name          string    `db:"name"`
+	Description   *string   `db:"description"`
+	Role          string    `db:"role"`
+	Grants        []byte    `db:"grants"`
+	IssuerConfig  []byte    `db:"issuer_config"`
+	SessionConfig []byte    `db:"session_config"`
+	CreatedAt     time.Time `db:"created_at"`
+	UpdatedAt     time.Time `db:"updated_at"`
+}
+
+func (r accessPolicyRow) toPolicy() (*AccessPolicy, error) {
+	p := AccessPolicy{
+		ID:          r.ID,
+		ProjectID:   r.ProjectID,
+		Type:        PolicyType(r.Type),
+		Name:        r.Name,
+		Description: r.Description,
+		Scope:       r.Scope,
+		Role:        r.Role,
+		Secret:      r.Value,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+	if err := decodeJSONB(r.Grants, &p.Grants); err != nil {
+		return nil, fmt.Errorf("management: decode grants for policy %s: %w", r.ID, err)
+	}
+	if len(r.IssuerConfig) > 0 {
+		if err := decodeJSONB(r.IssuerConfig, &p.IssuerConfig); err != nil {
+			return nil, fmt.Errorf("management: decode issuer_config for policy %s: %w", r.ID, err)
+		}
+	}
+	if len(r.SessionConfig) > 0 {
+		if err := decodeJSONB(r.SessionConfig, &p.SessionConfig); err != nil {
+			return nil, fmt.Errorf("management: decode session_config for policy %s: %w", r.ID, err)
+		}
+	}
+	return &p, nil
+}
+
+// decodeJSONB unmarshals a JSONB column into dst, treating SQL NULL and empty
+// payloads as a no-op so dst keeps its zero value.
+func decodeJSONB(raw []byte, dst any) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+// encodeJSONB marshals v for storage in a JSONB column, returning nil (SQL NULL)
+// for empty values so absent config is stored as NULL rather than "null".
+func encodeJSONB(v any) ([]byte, error) {
+	switch t := v.(type) {
+	case nil:
+		return nil, nil
+	case []Grant:
+		if len(t) == 0 {
+			return nil, nil
+		}
+	case *IssuerConfig:
+		if t == nil {
+			return nil, nil
+		}
+	case *SessionConfig:
+		if t == nil {
+			return nil, nil
+		}
+	}
+	return json.Marshal(v)
+}
+
+// CreateAccessPolicyInput carries the fields needed to create an access policy.
+// Type-specific fields are optional and validated by the caller.
+type CreateAccessPolicyInput struct {
+	Type          PolicyType
+	Name          string
+	Description   *string
+	Scope         *string
+	Role          string
+	Secret        *string
+	Grants        []Grant
+	IssuerConfig  *IssuerConfig
+	SessionConfig *SessionConfig
+}
+
+func NewAccessPoliciesStore(db store.DB) *AccessPoliciesStore {
+	return &AccessPoliciesStore{db: db}
+}
+
+type AccessPoliciesStore struct {
+	db store.DB
+}
+
+func (s *AccessPoliciesStore) CreateAccessPolicy(ctx context.Context, projectID uuid.UUID, in CreateAccessPolicyInput) (*AccessPolicy, error) {
+	grants, err := encodeJSONB(in.Grants)
+	if err != nil {
+		return nil, err
+	}
+	issuer, err := encodeJSONB(in.IssuerConfig)
+	if err != nil {
+		return nil, err
+	}
+	session, err := encodeJSONB(in.SessionConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	const stmt = `
+	INSERT INTO access_policies
+		(project_id, type, value, scope, name, description, role, grants, issuer_config, session_config)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	RETURNING id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at`
+
+	var row accessPolicyRow
+	err = s.db.GetContext(ctx, &row, stmt,
+		projectID, string(in.Type), in.Secret, in.Scope, in.Name, in.Description, in.Role, grants, issuer, session)
+	if err != nil {
+		return nil, err
+	}
+	return row.toPolicy()
+}
+
+func (s *AccessPoliciesStore) GetAccessPolicy(ctx context.Context, projectID, policyID uuid.UUID) (*AccessPolicy, error) {
+	const stmt = `
+	SELECT id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at
+	FROM access_policies
+	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
+
+	var row accessPolicyRow
+	if err := s.db.GetContext(ctx, &row, stmt, policyID, projectID); err != nil {
+		return nil, err
+	}
+	return row.toPolicy()
+}
+
+func (s *AccessPoliciesStore) ListAccessPolicies(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) ([]AccessPolicy, int, error) {
+	const stmt = `
+	SELECT id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config,
+	       created_at, updated_at, COUNT(*) OVER () AS total_count
+	FROM access_policies
+	WHERE project_id = $1 AND deleted_at IS NULL
+	ORDER BY created_at DESC
+	LIMIT $2 OFFSET $3`
+
+	type listRow struct {
+		accessPolicyRow
+		TotalCount int `db:"total_count"`
+	}
+
+	var rows []listRow
+	if err := s.db.SelectContext(ctx, &rows, stmt, projectID, pagination.Limit, pagination.Offset); err != nil {
+		return nil, 0, err
+	}
+	if len(rows) == 0 {
+		return []AccessPolicy{}, 0, nil
+	}
+
+	policies := make([]AccessPolicy, len(rows))
+	for i, r := range rows {
+		p, err := r.toPolicy()
+		if err != nil {
+			return nil, 0, err
+		}
+		policies[i] = *p
+	}
+	return policies, rows[0].TotalCount, nil
+}
+
+// UpdateAccessPolicyInput carries the mutable fields of an access policy. Nil
+// fields are left unchanged; Grants is only rewritten when non-nil.
+type UpdateAccessPolicyInput struct {
+	Name        *string
+	Description *string
+	Role        *string
+	Grants      []Grant
+}
+
+func (s *AccessPoliciesStore) UpdateAccessPolicy(ctx context.Context, projectID, policyID uuid.UUID, in UpdateAccessPolicyInput) error {
+	var grants []byte
+	if in.Grants != nil {
+		encoded, err := encodeJSONB(in.Grants)
+		if err != nil {
+			return err
+		}
+		grants = encoded
+	}
+
+	const stmt = `
+	UPDATE access_policies
+	SET name        = COALESCE($1, name),
+	    description = COALESCE($2, description),
+	    role        = COALESCE($3, role),
+	    grants      = CASE WHEN $4::boolean THEN $5::jsonb ELSE grants END
+	WHERE id = $6 AND project_id = $7 AND deleted_at IS NULL`
+
+	_, err := s.db.ExecContext(ctx, stmt,
+		in.Name, in.Description, in.Role, in.Grants != nil, grants, policyID, projectID)
+	return err
+}
+
+func (s *AccessPoliciesStore) DeleteAccessPolicy(ctx context.Context, projectID, policyID uuid.UUID) error {
+	const stmt = `
+	UPDATE access_policies
+	SET deleted_at = NOW()
+	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
+
+	_, err := s.db.ExecContext(ctx, stmt, policyID, projectID)
+	return err
+}

--- a/internal/store/management/accesspolicies.go
+++ b/internal/store/management/accesspolicies.go
@@ -21,6 +21,13 @@ const (
 	PolicyTypeSession       PolicyType = "session"
 )
 
+// Scope values recorded on an access policy's secret. Public keys are safe to
+// expose in client-side code; secret keys are backend-only.
+const (
+	ScopePublic = "public"
+	ScopeSecret = "secret"
+)
+
 // Grant is one (resource, verb) entry in a policy's custom permission set. It
 // mirrors access.Grant and is persisted in the access_policies.grants JSONB
 // column. An empty set means the policy uses its role preset instead.
@@ -173,6 +180,16 @@ type AccessPoliciesStore struct {
 }
 
 func (s *AccessPoliciesStore) CreateAccessPolicy(ctx context.Context, projectID uuid.UUID, in CreateAccessPolicyInput) (*AccessPolicy, error) {
+	// API-key policies carry a Lunogram-issued secret; generate one when the
+	// caller did not supply it.
+	if in.Type == PolicyTypeAPIKey && in.Secret == nil {
+		value, err := generateKeyValue()
+		if err != nil {
+			return nil, err
+		}
+		in.Secret = &value
+	}
+
 	grants, err := encodeJSONB(in.Grants)
 	if err != nil {
 		return nil, err

--- a/internal/store/management/accesspolicies.go
+++ b/internal/store/management/accesspolicies.go
@@ -65,9 +65,15 @@ type AccessPolicy struct {
 	Scope       *string
 	Role        string
 
-	// Secret is the raw key value for api_key policies. It is nil for policy
-	// types that carry no Lunogram-held secret (e.g. trusted_issuer).
+	// Secret is the full plaintext key. It is set only on the AccessPolicy
+	// returned by CreateAccessPolicy (shown to the caller exactly once) and is
+	// never read back from storage.
 	Secret *string
+
+	// SecretPrefix is the non-sensitive leading portion of the secret, used to
+	// identify an api_key policy in list views. It is nil for policy types that
+	// carry no secret.
+	SecretPrefix *string
 
 	// Grants is the custom permission set. Nil/empty means the policy resolves
 	// through its Role preset.
@@ -85,7 +91,7 @@ type accessPolicyRow struct {
 	ID            uuid.UUID `db:"id"`
 	ProjectID     uuid.UUID `db:"project_id"`
 	Type          string    `db:"type"`
-	Value         *string   `db:"value"`
+	SecretPrefix  *string   `db:"secret_prefix"`
 	Scope         *string   `db:"scope"`
 	Name          string    `db:"name"`
 	Description   *string   `db:"description"`
@@ -99,16 +105,16 @@ type accessPolicyRow struct {
 
 func (r accessPolicyRow) toPolicy() (*AccessPolicy, error) {
 	p := AccessPolicy{
-		ID:          r.ID,
-		ProjectID:   r.ProjectID,
-		Type:        PolicyType(r.Type),
-		Name:        r.Name,
-		Description: r.Description,
-		Scope:       r.Scope,
-		Role:        r.Role,
-		Secret:      r.Value,
-		CreatedAt:   r.CreatedAt,
-		UpdatedAt:   r.UpdatedAt,
+		ID:           r.ID,
+		ProjectID:    r.ProjectID,
+		Type:         PolicyType(r.Type),
+		Name:         r.Name,
+		Description:  r.Description,
+		Scope:        r.Scope,
+		Role:         r.Role,
+		SecretPrefix: r.SecretPrefix,
+		CreatedAt:    r.CreatedAt,
+		UpdatedAt:    r.UpdatedAt,
 	}
 	if err := decodeJSONB(r.Grants, &p.Grants); err != nil {
 		return nil, fmt.Errorf("management: decode grants for policy %s: %w", r.ID, err)
@@ -165,7 +171,6 @@ type CreateAccessPolicyInput struct {
 	Description   *string
 	Scope         *string
 	Role          string
-	Secret        *string
 	Grants        []Grant
 	IssuerConfig  *IssuerConfig
 	SessionConfig *SessionConfig
@@ -180,16 +185,6 @@ type AccessPoliciesStore struct {
 }
 
 func (s *AccessPoliciesStore) CreateAccessPolicy(ctx context.Context, projectID uuid.UUID, in CreateAccessPolicyInput) (*AccessPolicy, error) {
-	// API-key policies carry a Lunogram-issued secret; generate one when the
-	// caller did not supply it.
-	if in.Type == PolicyTypeAPIKey && in.Secret == nil {
-		value, err := generateKeyValue()
-		if err != nil {
-			return nil, err
-		}
-		in.Secret = &value
-	}
-
 	grants, err := encodeJSONB(in.Grants)
 	if err != nil {
 		return nil, err
@@ -203,24 +198,45 @@ func (s *AccessPoliciesStore) CreateAccessPolicy(ctx context.Context, projectID 
 		return nil, err
 	}
 
+	// API-key policies carry a Lunogram-issued secret. We store only its hash
+	// and display prefix; the plaintext is surfaced once on the returned policy.
+	var secretHash, secretPrefix, plaintext *string
+	if in.Type == PolicyTypeAPIKey {
+		scope := ScopeSecret
+		if in.Scope != nil {
+			scope = *in.Scope
+		}
+		pt, prefix, hash, err := newSecret(scope)
+		if err != nil {
+			return nil, err
+		}
+		plaintext, secretPrefix, secretHash = &pt, &prefix, &hash
+	}
+
 	const stmt = `
 	INSERT INTO access_policies
-		(project_id, type, value, scope, name, description, role, grants, issuer_config, session_config)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-	RETURNING id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at`
+		(project_id, type, secret_hash, secret_prefix, scope, name, description, role, grants, issuer_config, session_config)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	RETURNING id, project_id, type, secret_prefix, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at`
 
 	var row accessPolicyRow
 	err = s.db.GetContext(ctx, &row, stmt,
-		projectID, string(in.Type), in.Secret, in.Scope, in.Name, in.Description, in.Role, grants, issuer, session)
+		projectID, string(in.Type), secretHash, secretPrefix, in.Scope, in.Name, in.Description, in.Role, grants, issuer, session)
 	if err != nil {
 		return nil, err
 	}
-	return row.toPolicy()
+
+	policy, err := row.toPolicy()
+	if err != nil {
+		return nil, err
+	}
+	policy.Secret = plaintext // shown to the caller exactly once
+	return policy, nil
 }
 
 func (s *AccessPoliciesStore) GetAccessPolicy(ctx context.Context, projectID, policyID uuid.UUID) (*AccessPolicy, error) {
 	const stmt = `
-	SELECT id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at
+	SELECT id, project_id, type, secret_prefix, scope, name, description, role, grants, issuer_config, session_config, created_at, updated_at
 	FROM access_policies
 	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
 
@@ -233,7 +249,7 @@ func (s *AccessPoliciesStore) GetAccessPolicy(ctx context.Context, projectID, po
 
 func (s *AccessPoliciesStore) ListAccessPolicies(ctx context.Context, projectID uuid.UUID, pagination store.Pagination) ([]AccessPolicy, int, error) {
 	const stmt = `
-	SELECT id, project_id, type, value, scope, name, description, role, grants, issuer_config, session_config,
+	SELECT id, project_id, type, secret_prefix, scope, name, description, role, grants, issuer_config, session_config,
 	       created_at, updated_at, COUNT(*) OVER () AS total_count
 	FROM access_policies
 	WHERE project_id = $1 AND deleted_at IS NULL

--- a/internal/store/management/accesspolicies_test.go
+++ b/internal/store/management/accesspolicies_test.go
@@ -1,0 +1,142 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessPoliciesStore(t *testing.T) {
+	t.Parallel()
+	db := NewContainerStore(t)
+	ctx := context.Background()
+
+	orgID, err := db.CreateOrganization(ctx, "AP Org")
+	require.NoError(t, err)
+	projectID, err := db.CreateProject(ctx, Project{
+		OrganizationID: &orgID,
+		Name:           "AP Project",
+		Timezone:       "UTC",
+		Locale:         "en",
+	})
+	require.NoError(t, err)
+
+	t.Run("creates and reads back an api_key policy", func(t *testing.T) {
+		created, err := db.CreateAccessPolicy(ctx, projectID, CreateAccessPolicyInput{
+			Type:   PolicyTypeAPIKey,
+			Name:   "public ingest key",
+			Scope:  ptr.To("public"),
+			Role:   "client",
+			Secret: ptr.To("pk_secretvalue"),
+		})
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, created.ID)
+		assert.Equal(t, PolicyTypeAPIKey, created.Type)
+		assert.Equal(t, "client", created.Role)
+		assert.Equal(t, "pk_secretvalue", *created.Secret)
+		assert.Empty(t, created.Grants)
+		assert.Nil(t, created.IssuerConfig)
+
+		got, err := db.GetAccessPolicy(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, got.ID)
+		assert.Equal(t, "public ingest key", got.Name)
+
+		// The api_key policy must surface through the backward-compatible
+		// project_api_keys view that the legacy ApiKeysStore reads.
+		keys, _, err := db.ListApiKeys(ctx, projectID, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		assert.Equal(t, created.ID, keys[0].ID)
+	})
+
+	t.Run("round-trips typed grants and issuer config for a trusted_issuer policy", func(t *testing.T) {
+		created, err := db.CreateAccessPolicy(ctx, projectID, CreateAccessPolicyInput{
+			Type: PolicyTypeTrustedIssuer,
+			Name: "acme idp",
+			Role: "support",
+			Grants: []Grant{
+				{Resource: "inbox", Verb: "read"},
+				{Resource: "users", Verb: "read"},
+			},
+			IssuerConfig: &IssuerConfig{
+				JWKSURL:      "https://acme.example/.well-known/jwks.json",
+				Issuer:       "https://acme.example",
+				Audience:     "lunogram",
+				SubjectClaim: "sub",
+			},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, created.Secret)
+
+		got, err := db.GetAccessPolicy(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, PolicyTypeTrustedIssuer, got.Type)
+		assert.Equal(t, []Grant{{Resource: "inbox", Verb: "read"}, {Resource: "users", Verb: "read"}}, got.Grants)
+		require.NotNil(t, got.IssuerConfig)
+		assert.Equal(t, "https://acme.example/.well-known/jwks.json", got.IssuerConfig.JWKSURL)
+		assert.Equal(t, "sub", got.IssuerConfig.SubjectClaim)
+
+		// A non-api_key policy must NOT leak into the legacy view.
+		keys, _, err := db.ListApiKeys(ctx, projectID, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		for _, k := range keys {
+			assert.NotEqual(t, created.ID, k.ID, "trusted_issuer policy must not appear in project_api_keys view")
+		}
+	})
+
+	t.Run("round-trips a session policy config", func(t *testing.T) {
+		created, err := db.CreateAccessPolicy(ctx, projectID, CreateAccessPolicyInput{
+			Type:          PolicyTypeSession,
+			Name:          "web sessions",
+			Role:          "client",
+			SessionConfig: &SessionConfig{TTL: 15 * time.Minute, Role: "client"},
+		})
+		require.NoError(t, err)
+
+		got, err := db.GetAccessPolicy(ctx, projectID, created.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.SessionConfig)
+		assert.Equal(t, 15*time.Minute, got.SessionConfig.TTL)
+	})
+
+	t.Run("lists with total count and updates role + grants", func(t *testing.T) {
+		policies, total, err := db.ListAccessPolicies(ctx, projectID, store.Pagination{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 3, total)
+		assert.Len(t, policies, 3)
+
+		target := policies[0]
+		err = db.UpdateAccessPolicy(ctx, projectID, target.ID, UpdateAccessPolicyInput{
+			Role:   ptr.To("editor"),
+			Grants: []Grant{{Resource: "campaigns", Verb: "read"}},
+		})
+		require.NoError(t, err)
+
+		updated, err := db.GetAccessPolicy(ctx, projectID, target.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "editor", updated.Role)
+		assert.Equal(t, []Grant{{Resource: "campaigns", Verb: "read"}}, updated.Grants)
+	})
+
+	t.Run("soft deletes", func(t *testing.T) {
+		created, err := db.CreateAccessPolicy(ctx, projectID, CreateAccessPolicyInput{
+			Type: PolicyTypeAPIKey,
+			Name: "to delete",
+			Role: "support",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, db.DeleteAccessPolicy(ctx, projectID, created.ID))
+
+		_, err = db.GetAccessPolicy(ctx, projectID, created.ID)
+		assert.True(t, errors.Is(err, store.ErrNoRows), "deleted policy should not be found")
+	})
+}

--- a/internal/store/management/accesspolicies_test.go
+++ b/internal/store/management/accesspolicies_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,17 +31,19 @@ func TestAccessPoliciesStore(t *testing.T) {
 
 	t.Run("creates and reads back an api_key policy", func(t *testing.T) {
 		created, err := db.CreateAccessPolicy(ctx, projectID, CreateAccessPolicyInput{
-			Type:   PolicyTypeAPIKey,
-			Name:   "public ingest key",
-			Scope:  ptr.To("public"),
-			Role:   "client",
-			Secret: ptr.To("pk_secretvalue"),
+			Type:  PolicyTypeAPIKey,
+			Name:  "public ingest key",
+			Scope: ptr.To("public"),
+			Role:  "client",
 		})
 		require.NoError(t, err)
 		assert.NotEqual(t, uuid.Nil, created.ID)
 		assert.Equal(t, PolicyTypeAPIKey, created.Type)
 		assert.Equal(t, "client", created.Role)
-		assert.Equal(t, "pk_secretvalue", *created.Secret)
+		// The full secret is generated and shown exactly once, prefixed pk_.
+		require.NotNil(t, created.Secret)
+		assert.True(t, strings.HasPrefix(*created.Secret, "pk_"), "public key should be prefixed pk_")
+		require.NotNil(t, created.SecretPrefix)
 		assert.Empty(t, created.Grants)
 		assert.Nil(t, created.IssuerConfig)
 
@@ -48,6 +51,9 @@ func TestAccessPoliciesStore(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, created.ID, got.ID)
 		assert.Equal(t, "public ingest key", got.Name)
+		// Reads never expose the plaintext, only the prefix.
+		assert.Nil(t, got.Secret)
+		require.NotNil(t, got.SecretPrefix)
 
 		// The api_key policy must surface through the backward-compatible
 		// project_api_keys view that the legacy ApiKeysStore reads.

--- a/internal/store/management/apikeys.go
+++ b/internal/store/management/apikeys.go
@@ -22,22 +22,34 @@ func (keys ApiKeys) OAPI() []oapi.ApiKey {
 }
 
 type ApiKey struct {
-	ID          uuid.UUID `db:"id"`
-	ProjectID   uuid.UUID `db:"project_id"`
-	Value       string    `db:"value"`
-	Scope       *string   `db:"scope"`
-	Name        string    `db:"name"`
-	Description *string   `db:"description"`
-	Role        string    `db:"role"`
-	CreatedAt   time.Time `db:"created_at"`
-	UpdatedAt   time.Time `db:"updated_at"`
+	ID           uuid.UUID `db:"id"`
+	ProjectID    uuid.UUID `db:"project_id"`
+	SecretHash   *string   `db:"secret_hash"`
+	SecretPrefix *string   `db:"secret_prefix"`
+	Scope        *string   `db:"scope"`
+	Name         string    `db:"name"`
+	Description  *string   `db:"description"`
+	Role         string    `db:"role"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
+
+	// Plaintext holds the full secret and is populated only by CreateApiKey, so
+	// the value is shown to the caller exactly once on creation.
+	Plaintext string `db:"-"`
 }
 
 func (k *ApiKey) OAPI() oapi.ApiKey {
+	// The full secret is returned only on creation (Plaintext); afterwards only
+	// the display prefix is exposed.
+	value := k.Plaintext
+	if value == "" && k.SecretPrefix != nil {
+		value = *k.SecretPrefix
+	}
+
 	result := oapi.ApiKey{
 		Id:        k.ID,
 		ProjectId: k.ProjectID,
-		Value:     k.Value,
+		Value:     value,
 		Name:      k.Name,
 		Role:      oapi.ProjectRole(k.Role),
 		CreatedAt: k.CreatedAt,
@@ -73,28 +85,29 @@ func generateKeyValue() (string, error) {
 }
 
 func (s *ApiKeysStore) CreateApiKey(ctx context.Context, projectID uuid.UUID, name string, scope string, role string, description *string) (*ApiKey, error) {
-	keyValue, err := generateKeyValue()
+	plaintext, prefix, hash, err := newSecret(scope)
 	if err != nil {
 		return nil, err
 	}
 
 	stmt := `
-	INSERT INTO project_api_keys (project_id, value, scope, name, description, role)
-	VALUES ($1, $2, $3, $4, $5, $6)
-	RETURNING id, project_id, value, scope, name, description, role, created_at, updated_at`
+	INSERT INTO project_api_keys (project_id, secret_hash, secret_prefix, scope, name, description, role)
+	VALUES ($1, $2, $3, $4, $5, $6, $7)
+	RETURNING id, project_id, secret_hash, secret_prefix, scope, name, description, role, created_at, updated_at`
 
 	var apiKey ApiKey
-	err = s.db.GetContext(ctx, &apiKey, stmt, projectID, keyValue, scope, name, description, role)
+	err = s.db.GetContext(ctx, &apiKey, stmt, projectID, hash, prefix, scope, name, description, role)
 	if err != nil {
 		return nil, err
 	}
 
+	apiKey.Plaintext = plaintext // shown to the caller exactly once
 	return &apiKey, nil
 }
 
 func (s *ApiKeysStore) GetApiKey(ctx context.Context, projectID, keyID uuid.UUID) (*ApiKey, error) {
 	stmt := `
-	SELECT id, project_id, value, scope, name, description, role, created_at, updated_at
+	SELECT id, project_id, secret_hash, secret_prefix, scope, name, description, role, created_at, updated_at
 	FROM project_api_keys
 	WHERE id = $1 AND project_id = $2 AND deleted_at IS NULL`
 
@@ -112,7 +125,8 @@ func (s *ApiKeysStore) ListApiKeys(ctx context.Context, projectID uuid.UUID, pag
 	SELECT
 		id,
 		project_id,
-		value,
+		secret_hash,
+		secret_prefix,
 		scope,
 		name,
 		description,

--- a/internal/store/management/auth.go
+++ b/internal/store/management/auth.go
@@ -11,7 +11,7 @@ type APIKey struct {
 	ID             string    `db:"id"`
 	OrganizationID uuid.UUID `db:"organization_id"`
 	ProjectID      uuid.UUID `db:"project_id"`
-	Value          string    `db:"value"`
+	SecretHash     *string   `db:"secret_hash"`
 	Scope          *string   `db:"scope"`
 	Name           string    `db:"name"`
 	Description    *string   `db:"description"`
@@ -28,15 +28,17 @@ type AuthStore struct {
 	db store.DB
 }
 
+// GetAPIKeyBySecret looks up an API key by the presented plaintext secret. The
+// secret is matched by its SHA-256 hash; the plaintext is never stored.
 func (s *AuthStore) GetAPIKeyBySecret(key string) (*APIKey, error) {
 	query := `
-	SELECT k.id, p.organization_id, k.project_id, k.value, k.scope, k.name, k.description, k.created_at, k.updated_at, k.role
+	SELECT k.id, p.organization_id, k.project_id, k.secret_hash, k.scope, k.name, k.description, k.created_at, k.updated_at, k.role
 	FROM project_api_keys k
 	JOIN projects p ON p.id = k.project_id
-	WHERE value = $1`
+	WHERE k.secret_hash = $1`
 
 	result := APIKey{}
-	err := s.db.Get(&result, query, key)
+	err := s.db.Get(&result, query, hashSecret(key))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/management/migrations/1764116038_access_policies.down.sql
+++ b/internal/store/management/migrations/1764116038_access_policies.down.sql
@@ -1,0 +1,15 @@
+-- Reverse the access_policies generalization. Non-API-key policies (if any) are
+-- dropped because the original project_api_keys table only modelled API keys.
+
+DROP VIEW IF EXISTS project_api_keys;
+
+DELETE FROM access_policies WHERE type <> 'api_key';
+
+ALTER TABLE access_policies DROP COLUMN IF EXISTS session_config;
+ALTER TABLE access_policies DROP COLUMN IF EXISTS issuer_config;
+ALTER TABLE access_policies DROP COLUMN IF EXISTS grants;
+ALTER TABLE access_policies DROP COLUMN IF EXISTS type;
+
+ALTER TABLE access_policies ALTER COLUMN value SET NOT NULL;
+
+ALTER TABLE access_policies RENAME TO project_api_keys;

--- a/internal/store/management/migrations/1764116038_access_policies.up.sql
+++ b/internal/store/management/migrations/1764116038_access_policies.up.sql
@@ -1,0 +1,48 @@
+-- Migration: Generalize project_api_keys into access_policies
+-- Purpose: An access policy is a project-scoped configuration of *how* a client
+-- authenticates to the API. The API key is the first policy type; trusted-issuer
+-- (JWKS / public cert) and short-term session policies are layered on top via the
+-- type discriminator and the *_config columns below.
+--
+-- The original project_api_keys table is renamed (so its data, indexes and
+-- triggers are preserved) and re-exposed as an auto-updatable view, letting the
+-- existing API-key store and auth lookups keep working unchanged during the
+-- transition.
+
+ALTER TABLE project_api_keys RENAME TO access_policies;
+
+-- Policy type discriminator. Every existing row is an API key.
+ALTER TABLE access_policies
+    ADD COLUMN type VARCHAR(32) NOT NULL DEFAULT 'api_key';
+
+-- The secret (value) only applies to API-key and session policies; trusted-issuer
+-- policies have no Lunogram-held secret.
+ALTER TABLE access_policies
+    ALTER COLUMN value DROP NOT NULL;
+
+-- Custom permission set: a JSON array of {"resource","verb"} grants. NULL means
+-- the policy uses its role preset (support/client/editor/admin) rather than a
+-- custom scope.
+ALTER TABLE access_policies
+    ADD COLUMN grants JSONB;
+
+-- Trusted-issuer configuration (JWKS url / PEM cert, iss, aud, subject claim),
+-- populated for type = 'trusted_issuer'.
+ALTER TABLE access_policies
+    ADD COLUMN issuer_config JSONB;
+
+-- Session-signing configuration (TTL, granted role/scope), populated for
+-- type = 'session'.
+ALTER TABLE access_policies
+    ADD COLUMN session_config JSONB;
+
+-- Backward-compatible view over the API-key rows. Postgres keeps this view
+-- auto-updatable (single source table, plain columns, type defaults to
+-- 'api_key' so inserts land as API keys), so existing project_api_keys
+-- queries — including INSERT ... RETURNING and soft-delete UPDATEs — keep
+-- working without code changes.
+CREATE VIEW project_api_keys AS
+    SELECT id, project_id, value, scope, name, description, role,
+           created_at, updated_at, deleted_at
+    FROM access_policies
+    WHERE type = 'api_key';

--- a/internal/store/management/migrations/1764116039_access_policy_secret_hash.down.sql
+++ b/internal/store/management/migrations/1764116039_access_policy_secret_hash.down.sql
@@ -1,0 +1,16 @@
+-- Reverse secret hashing. The plaintext cannot be recovered from the hash, so
+-- the restored value column is left NULL; existing keys must be reissued.
+
+DROP VIEW IF EXISTS project_api_keys;
+DROP INDEX IF EXISTS access_policies_secret_hash_uniq;
+
+ALTER TABLE access_policies ADD COLUMN value VARCHAR(255);
+
+ALTER TABLE access_policies DROP COLUMN secret_prefix;
+ALTER TABLE access_policies DROP COLUMN secret_hash;
+
+CREATE VIEW project_api_keys AS
+    SELECT id, project_id, value, scope, name, description, role,
+           created_at, updated_at, deleted_at
+    FROM access_policies
+    WHERE type = 'api_key';

--- a/internal/store/management/migrations/1764116039_access_policy_secret_hash.up.sql
+++ b/internal/store/management/migrations/1764116039_access_policy_secret_hash.up.sql
@@ -1,0 +1,33 @@
+-- Migration: Hash access-policy secrets at rest
+-- Purpose: Stop storing plaintext API secrets. Secrets are now identified by a
+-- SHA-256 hash (the lookup key) plus a short display prefix; the plaintext value
+-- column is dropped. Existing secrets are backfilled from their plaintext before
+-- it is removed, so existing keys keep authenticating.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE access_policies ADD COLUMN secret_hash TEXT;
+ALTER TABLE access_policies ADD COLUMN secret_prefix TEXT;
+
+-- Backfill from the existing plaintext, matching management.hashSecret
+-- (hex-encoded SHA-256).
+UPDATE access_policies
+SET secret_hash   = encode(digest(value, 'sha256'), 'hex'),
+    secret_prefix = left(value, 11)
+WHERE value IS NOT NULL;
+
+-- Recreate the compatibility view without the plaintext column. Dropping the
+-- column also drops the old project_api_keys_value_uniq index.
+DROP VIEW IF EXISTS project_api_keys;
+
+ALTER TABLE access_policies DROP COLUMN value;
+
+CREATE VIEW project_api_keys AS
+    SELECT id, project_id, secret_hash, secret_prefix, scope, name, description, role,
+           created_at, updated_at, deleted_at
+    FROM access_policies
+    WHERE type = 'api_key';
+
+CREATE UNIQUE INDEX access_policies_secret_hash_uniq
+    ON access_policies(secret_hash)
+    WHERE secret_hash IS NOT NULL;

--- a/internal/store/management/secrets.go
+++ b/internal/store/management/secrets.go
@@ -1,0 +1,47 @@
+package management
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// secretPrefixLen is the number of leading characters of a secret retained for
+// display/identification (e.g. "pk_" plus 8 hex characters).
+const secretPrefixLen = 11
+
+// hashSecret returns the hex-encoded SHA-256 of a secret. Secrets are stored and
+// looked up by this hash so the plaintext is never persisted. It matches the
+// pgcrypto expression used by the backfill migration:
+// encode(digest(value, 'sha256'), 'hex').
+func hashSecret(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// secretPrefix returns the leading, non-sensitive portion of a secret, used to
+// identify a key in list views without revealing it.
+func secretPrefix(secret string) string {
+	if len(secret) <= secretPrefixLen {
+		return secret
+	}
+	return secret[:secretPrefixLen]
+}
+
+// newSecret generates a fresh API secret for the given scope. It returns the
+// full plaintext (shown to the caller exactly once), its display prefix, and the
+// hash to persist. Public keys are prefixed "pk_" and secret keys "sk_" so they
+// are recognisable and detectable by secret scanners.
+func newSecret(scope string) (plaintext, prefix, hash string, err error) {
+	raw, err := generateKeyValue()
+	if err != nil {
+		return "", "", "", err
+	}
+
+	tag := "sk_"
+	if scope == ScopePublic {
+		tag = "pk_"
+	}
+
+	plaintext = tag + raw
+	return plaintext, secretPrefix(plaintext), hashSecret(plaintext), nil
+}

--- a/internal/store/management/secrets_test.go
+++ b/internal/store/management/secrets_test.go
@@ -1,0 +1,35 @@
+package management
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashSecretIsDeterministic(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, hashSecret("pk_abc"), hashSecret("pk_abc"))
+	assert.NotEqual(t, hashSecret("pk_abc"), hashSecret("pk_abd"))
+	assert.Len(t, hashSecret("anything"), 64) // hex-encoded SHA-256
+}
+
+func TestNewSecretPrefixesByScope(t *testing.T) {
+	t.Parallel()
+
+	pub, pubPrefix, pubHash, err := newSecret(ScopePublic)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(pub, "pk_"))
+	assert.Equal(t, pub[:secretPrefixLen], pubPrefix)
+	assert.Equal(t, hashSecret(pub), pubHash)
+
+	sec, _, _, err := newSecret(ScopeSecret)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(sec, "sk_"))
+
+	// Two generations never collide.
+	other, _, _, err := newSecret(ScopePublic)
+	require.NoError(t, err)
+	assert.NotEqual(t, pub, other)
+}

--- a/internal/store/management/store.go
+++ b/internal/store/management/store.go
@@ -18,6 +18,7 @@ func NewState(db store.DB) *State {
 		DocumentsStore:            NewDocumentsStore(db),
 		AuthStore:                 NewAuthStore(db),
 		ApiKeysStore:              NewApiKeysStore(db),
+		AccessPoliciesStore:       NewAccessPoliciesStore(db),
 		ActionsStore:              NewActionsStore(db),
 		SenderIdentitiesStore:     NewSenderIdentitiesStore(db),
 		BroadcastsStore:           NewBroadcastsStore(db),
@@ -39,6 +40,7 @@ type State struct {
 	*DocumentsStore
 	*AuthStore
 	*ApiKeysStore
+	*AccessPoliciesStore
 	*ActionsStore
 	*SenderIdentitiesStore
 	*BroadcastsStore


### PR DESCRIPTION
**PR 5 of the client-side API access series (RFC 0001).** Stacked on #247. Stops storing plaintext API secrets.

> ⚠️ **Breaking (intentional, per the RFC's show-once decision):** the legacy `/keys` list/get no longer return the full secret — only a display prefix. The full secret is returned **exactly once**, in the create response. The current console's "view key value" stops working until the `Settings → Access` UI lands.

## What's here
- **Migration 1764116039**: add `secret_hash` + `secret_prefix`; backfill `secret_hash` from existing plaintext (pgcrypto SHA-256, matching `management.hashSecret`); **drop the plaintext `value` column**; recreate the `project_api_keys` compatibility view over the new columns; unique index on `secret_hash`. Existing keys keep authenticating.
- Secrets are generated with a scope-based prefix — **`pk_`** (public) / **`sk_`** (secret) — so they're recognisable and catchable by secret scanners. Only the SHA-256 hash + short prefix are persisted.
- `GetAPIKeyBySecret` matches by **hash** of the presented secret.
- Both the `access_policies` store and the legacy api-key store updated: create surfaces the plaintext once; reads expose only the prefix.

## Verification
- `go build ./...`, `go vet ./...`, gofmt clean.
- **Container tests** (real Postgres) exercise the migration + hashing end-to-end; the api_key/trusted_issuer/session round-trips and the compat view all still pass.
- Unit tests for the hash/prefix helpers (determinism, scope prefixes, no collisions).

## Next
PR 6 — console `Settings → Access` UI. Then JWKS trusted-issuer, sessions, own-data + event allow-list, SDK/docs.