### PR TITLE
feat(journeys): emit journey.step.entered event on step entry

### DIFF
--- a/internal/pubsub/consumer/journeys.go
+++ b/internal/pubsub/consumer/journeys.go
@@ -51,6 +51,23 @@ func JourneyStepHandler(logger *zap.Logger, db *sqlx.DB, jrny *journey.State, mg
 			return err
 		}
 
+		// Emit the tracked "journey.step.entered" event before executing the step.
+		// Publishing first means a transient failure retries the whole message
+		// before any step side effects run; the deterministic Msg-Id (keyed on the
+		// inbound message's stream sequence) collapses that retry so the event is
+		// counted exactly once per step entry.
+		var sourceSeq uint64
+		if meta, err := msg.Metadata(); err == nil {
+			sourceSeq = meta.Sequence.Stream
+		}
+		entered := schemas.JourneyStepEntered(event.ProjectID, event.JourneyID, event.JourneyEntryID, event.UserID, event.VersionID, step.ExternalID, step.Type, step.Name)
+		enteredMsgID := schemas.JourneyStepEnteredMsgID(event.JourneyEntryID, step.ExternalID, sourceSeq)
+		err = pub.Publish(ctx, schemas.UserEventsProcess(event.ProjectID), entered, pubsub.WithMsgID(enteredMsgID))
+		if err != nil {
+			logger.Error("failed to publish journey step entered event", zap.Error(err))
+			return err
+		}
+
 		data, err := jrny.GetJourneyEntryData(ctx, db, event.JourneyEntryID, event.UserID)
 		if err != nil {
 			logger.Error("failed to get journey entry data", zap.Error(err))

--- a/internal/pubsub/schemas/events.go
+++ b/internal/pubsub/schemas/events.go
@@ -32,6 +32,12 @@ const (
 	EventInboxMessageSent        = "inbox.message.sent"
 
 	EventProjectCreated = "project.created"
+
+	// EventJourneyStepEntered is the tracked user event emitted whenever a user
+	// enters a journey step. It flows through the standard user-event pipeline so
+	// it is registered, stored, and countable by rules — enabling gate steps such
+	// as "continue if the user has entered step X at least N times".
+	EventJourneyStepEntered = "journey.step.entered"
 )
 
 // InboxDispatchMsgID returns the deterministic JetStream Msg-Id used to dedupe
@@ -48,6 +54,17 @@ func InboxDispatchMsgID(messageID uuid.UUID, providerID uuid.UUID) string {
 // the stream's Duplicates window.
 func InboxProcessMsgID(messageID uuid.UUID) string {
 	return fmt.Sprintf("inbox-process:%s", messageID)
+}
+
+// JourneyStepEnteredMsgID returns the deterministic JetStream Msg-Id used to
+// dedupe the journey.step.entered event for a single step entry. The source
+// stream sequence of the inbound step message is stable across redeliveries but
+// unique per distinct step entry (a re-entry on a journey loop is a separate
+// inbound message with its own sequence), so the count stays accurate while
+// redeliveries collapse within the user-events stream's Duplicates window. The
+// entry and step identifiers are included for readability and namespacing.
+func JourneyStepEnteredMsgID(journeyEntryID uuid.UUID, externalStepID string, sourceSeq uint64) string {
+	return fmt.Sprintf("journey-step-entered:%s:%s:%d", journeyEntryID, externalStepID, sourceSeq)
 }
 
 // ExternalID is an alias for subjects.ExternalIDParam so that pubsub messages
@@ -152,6 +169,34 @@ type JourneyStep struct {
 	ExternalStepID string     `json:"external_step_id"`
 	StepType       string     `json:"step_type"`
 	StateID        *uuid.UUID `json:"state_id,omitempty"`
+}
+
+// JourneyStepEntered builds the tracked user event emitted when a user enters a
+// journey step. It is published as a regular UserEvent (to UserEventsProcess) so
+// it is registered, stored in user_events, and countable by the rules engine —
+// letting gate steps reason about how often a user has reached a given step. The
+// step descriptor lives under Data alongside the journey and entry identifiers so
+// gate rules can filter on data.journey_id, data.step_id, etc.
+func JourneyStepEntered(projectID, journeyID, journeyEntryID, userID uuid.UUID, versionID *uuid.UUID, stepID, stepType string, stepName *string) UserEvent {
+	data := map[string]any{
+		"journey_id":       journeyID,
+		"journey_entry_id": journeyEntryID,
+		"step_id":          stepID,
+		"step_type":        stepType,
+	}
+	if versionID != nil {
+		data["version_id"] = *versionID
+	}
+	if stepName != nil {
+		data["step_name"] = *stepName
+	}
+
+	return UserEvent{
+		Name:      EventJourneyStepEntered,
+		ProjectID: projectID,
+		UserID:    userID,
+		Data:      data,
+	}
 }
 
 // JourneyStepExecuted is published when a user completes their final step in a journey.

--- a/internal/pubsub/schemas/events_test.go
+++ b/internal/pubsub/schemas/events_test.go
@@ -1,0 +1,73 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJourneyStepEntered(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	journeyID := uuid.New()
+	entryID := uuid.New()
+	userID := uuid.New()
+	versionID := uuid.New()
+	name := "Welcome email"
+
+	event := JourneyStepEntered(projectID, journeyID, entryID, userID, &versionID, "step-1", "campaign", &name)
+
+	assert.Equal(t, EventJourneyStepEntered, event.Name)
+	assert.Equal(t, projectID, event.ProjectID)
+	assert.Equal(t, userID, event.UserID)
+
+	// Journey and step provenance lives under Data so gate rules can filter on it.
+	assert.Equal(t, journeyID, event.Data["journey_id"])
+	assert.Equal(t, entryID, event.Data["journey_entry_id"])
+	assert.Equal(t, versionID, event.Data["version_id"])
+	assert.Equal(t, "step-1", event.Data["step_id"])
+	assert.Equal(t, "campaign", event.Data["step_type"])
+	assert.Equal(t, name, event.Data["step_name"])
+}
+
+func TestJourneyStepEnteredOmitsOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	event := JourneyStepEntered(uuid.New(), uuid.New(), uuid.New(), uuid.New(), nil, "step-1", "delay", nil)
+
+	_, hasVersion := event.Data["version_id"]
+	assert.False(t, hasVersion, "version_id should be omitted when nil")
+
+	_, hasName := event.Data["step_name"]
+	assert.False(t, hasName, "step_name should be omitted when nil")
+}
+
+// TestJourneyStepEnteredMsgID verifies the dedup key is stable for a given step
+// entry (so redeliveries collapse) yet distinct across entries and step nodes
+// (so genuine re-entries on a loop are still counted).
+func TestJourneyStepEnteredMsgID(t *testing.T) {
+	t.Parallel()
+
+	entryID := uuid.New()
+
+	// Same entry + step + source sequence -> identical (redelivery dedup).
+	require.Equal(t,
+		JourneyStepEnteredMsgID(entryID, "step-1", 42),
+		JourneyStepEnteredMsgID(entryID, "step-1", 42),
+	)
+
+	// A distinct inbound message (new source sequence) is a distinct entry.
+	require.NotEqual(t,
+		JourneyStepEnteredMsgID(entryID, "step-1", 42),
+		JourneyStepEnteredMsgID(entryID, "step-1", 43),
+	)
+
+	// Different step node within the same entry is distinct.
+	require.NotEqual(t,
+		JourneyStepEnteredMsgID(entryID, "step-1", 42),
+		JourneyStepEnteredMsgID(entryID, "step-2", 42),
+	)
+}


### PR DESCRIPTION
## What

Fires a tracked user event named **`journey.step.entered`** whenever a user advances into a journey step (action, delay, gate, campaign, exit, etc.).

The event is published through the standard user-event pipeline (`UserEventsProcess`), so it is:
- **registered** as an event name (`UpsertEvent`) → selectable when building rules,
- **stored** in `user_events` (JSONB `data`, GIN-indexed) → countable & filterable,
- **schema-discovered** → its data paths surface for the rule-building UI.

This unlocks journey **gate** conditions like *"continue if the user has entered step X at least N times"*, since gates evaluate against the stored `user_events` rows (with frequency + `since_entered`/rolling/absolute windows).

## Payload

`Data` carries the step + journey provenance so gate rules can filter on it:

| field | source |
|---|---|
| `journey_id` | journey aggregate id |
| `journey_entry_id` | the user's entry into the journey |
| `version_id` | pinned journey version |
| `step_id` | step external id |
| `step_type` | e.g. `campaign`, `delay`, `gate` |
| `step_name` | optional, omitted when unset |

## Design notes

- **Fired before the step executes.** A transient publish failure retries the whole message before any step side effects run.
- **Exactly-once counting.** The dedup `Msg-Id` is keyed on the inbound step message's JetStream stream sequence — stable across redeliveries (collapses double counts via the `users.events` stream's 1h `Duplicates` window) yet unique per genuine pass, so loop re-entries are still counted.
- **Entrance node excluded** by design — it is already represented by the originating trigger event.
- **Always on** for all journeys (events back billing; volume is expected/acceptable).

## Tests

Unit tests for the event constructor (incl. optional-field omission) and the dedup-key stability/distinctness in `internal/pubsub/schemas/events_test.go`.