### PR TITLE
feat(campaign): add inbox channel to campaign editor

### DIFF
--- a/console/public/locales/en.json
+++ b/console/public/locales/en.json
@@ -109,6 +109,25 @@
                     },
                     "preview_disclaimer": "Preview only, notifications may display differently."
                 },
+                "inbox": {
+                    "title": {
+                        "label": "Title",
+                        "placeholder": "Message title"
+                    },
+                    "body": {
+                        "label": "Body",
+                        "placeholder": "Message body shown to the recipient"
+                    },
+                    "new": "new",
+                    "no_title": "No title",
+                    "sample": {
+                        "title_1": "Welcome aboard",
+                        "body_1": "Thanks for joining. Here are a few tips to get you started.",
+                        "title_2": "Your weekly summary",
+                        "body_2": "A recap of everything that happened this week."
+                    },
+                    "preview_disclaimer": "Preview only, the in-app inbox may display differently."
+                },
                 "webhook": {
                     "headers": {
                         "label": "Headers",
@@ -185,6 +204,10 @@
         "push": {
             "title": "Push Notification",
             "description": "Send push notifications to mobile devices for instant engagement."
+        },
+        "inbox": {
+            "title": "Inbox",
+            "description": "Send messages to your users' in-app inbox for persistent, in-product communication."
         },
         "webhook": {
             "title": "Webhook",
@@ -602,6 +625,7 @@
     "publish": "Publish",
     "published": "Published",
     "push": "Push",
+    "inbox": "Inbox",
     "queue_start": "Start Queue",
     "queue_pause": "Pause Queue",
     "rate_interval": "Rate Interval",

--- a/console/src/components/icons.tsx
+++ b/console/src/components/icons.tsx
@@ -246,23 +246,6 @@ export const PushIcon = () => (
     </svg>
 )
 
-export const InboxIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={1.5}
-        stroke="currentColor"
-        className="icon"
-    >
-        <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"
-        />
-    </svg>
-)
-
 export const BookIcon = () => (
     <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/console/src/components/icons.tsx
+++ b/console/src/components/icons.tsx
@@ -246,6 +246,23 @@ export const PushIcon = () => (
     </svg>
 )
 
+export const InboxIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="icon"
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"
+        />
+    </svg>
+)
+
 export const BookIcon = () => (
     <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/console/src/components/preview.tsx
+++ b/console/src/components/preview.tsx
@@ -8,6 +8,7 @@ import { ProjectContext } from "../contexts"
 import clsx from "clsx"
 import { compileEmail } from "@/views/campaign/template/mail/editor/codeEditor/compileEmail"
 import { getSystemPreviewProps } from "@/views/campaign/template/mail/editor/variableScope"
+import { InboxNotificationCenter } from "@/views/campaign/template/inbox/InboxNotificationCenter"
 
 interface PreviewProps {
     template: Pick<Template, "type" | "data">
@@ -102,6 +103,12 @@ export default function Preview({ template, size = "large" }: PreviewProps) {
                     </div>
                     <span className="notification-body">{data.body}</span>
                 </div>
+            </div>
+        )
+    } else if (type === "inbox") {
+        preview = (
+            <div className="p-4">
+                <InboxNotificationCenter title={data.title} body={data.body} />
             </div>
         )
     }

--- a/console/src/components/ui/template-input.tsx
+++ b/console/src/components/ui/template-input.tsx
@@ -74,6 +74,8 @@ export interface TemplateInputProps {
     id?: string
     /** Visual variant. "compact" matches small inline inputs (e.g. rule editor). */
     variant?: keyof typeof variantStyles
+    /** Render as a multi-line, wrapping editor (textarea-like) instead of a single line. */
+    multiline?: boolean
 }
 
 export function TemplateInput({
@@ -85,6 +87,7 @@ export function TemplateInput({
     disabled,
     id,
     variant = "default",
+    multiline = false,
 }: TemplateInputProps) {
     const [pickerOpen, setPickerOpen] = useState(false)
     const editorRef = useRef<HTMLDivElement>(null)
@@ -154,6 +157,12 @@ export function TemplateInput({
         const el = editorRef.current
         if (!el) return
         const plain = domToPlain(el)
+        // Deleting all content leaves a stray <br>/empty node behind, which
+        // suppresses the :empty placeholder and shifts the caret. Reset to a
+        // truly empty element so the caret and placeholder behave.
+        if (plain === "" && el.innerHTML !== "") {
+            el.innerHTML = ""
+        }
         if (plain !== valueRef.current) {
             onChange(plain)
         }
@@ -210,17 +219,36 @@ export function TemplateInput({
         [onChange, value],
     )
 
-    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-        if (e.key === "Enter") {
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key !== "Enter") return
             e.preventDefault()
-        }
-    }, [])
+            // Single-line inputs swallow Enter. Multi-line editors insert a real
+            // newline at the caret; `white-space: pre-wrap` renders it.
+            if (!multiline) return
+            const sel = window.getSelection()
+            if (!sel || sel.rangeCount === 0) return
+            const range = sel.getRangeAt(0)
+            range.deleteContents()
+            const newline = document.createTextNode("\n")
+            range.insertNode(newline)
+            // A trailing ZWS gives the caret somewhere to land on the new line.
+            const caret = document.createTextNode(ZWS)
+            newline.after(caret)
+            range.setStart(caret, caret.length)
+            range.collapse(true)
+            sel.removeAllRanges()
+            sel.addRange(range)
+            handleInput()
+        },
+        [multiline, handleInput],
+    )
 
     const hasVariables = variables.some((g) => g.variables.length > 0)
     const vs = variantStyles[variant]
 
     return (
-        <div className={cn("relative flex items-center", className)}>
+        <div className={cn("relative flex", multiline ? "items-start" : "items-center", className)}>
             {/* Editable area */}
             <div
                 ref={editorRef}
@@ -239,18 +267,19 @@ export function TemplateInput({
                 }}
                 data-placeholder={placeholder}
                 className={cn(
-                    "flex w-full border border-input bg-transparent transition-colors",
+                    "w-full border border-input bg-transparent transition-colors",
                     vs.editor,
                     "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                     "disabled:cursor-not-allowed disabled:opacity-50",
                     "empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground empty:before:pointer-events-none",
-                    "overflow-x-auto overflow-y-hidden whitespace-nowrap",
-                    "[&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]",
+                    multiline
+                        ? "block min-h-24 resize-y whitespace-pre-wrap break-words overflow-y-auto py-2"
+                        : "flex items-center overflow-x-auto overflow-y-hidden whitespace-nowrap [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]",
                     hasVariables && "pr-9",
                     disabled && "cursor-not-allowed opacity-50",
                     className,
                 )}
-                style={vs.style}
+                style={multiline ? { minHeight: "6rem", lineHeight: "1.5rem" } : vs.style}
             />
 
             {/* Variable picker trigger */}
@@ -260,7 +289,8 @@ export function TemplateInput({
                         <button
                             type="button"
                             className={cn(
-                                "absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center justify-center",
+                                "absolute right-1.5 flex items-center justify-center",
+                                multiline ? "top-2" : "top-1/2 -translate-y-1/2",
                                 "h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors",
                             )}
                             tabIndex={-1}

--- a/console/src/types.ts
+++ b/console/src/types.ts
@@ -369,7 +369,7 @@ export interface Project {
     lists_count?: number
 }
 
-export type ChannelType = "email" | "push" | "sms"
+export type ChannelType = "email" | "push" | "sms" | "inbox"
 
 export type ProjectCreate = Omit<Project, "id" | AuditFields>
 
@@ -711,11 +711,21 @@ export interface PushTemplateData {
     custom: Record<string, unknown>
 }
 
+export interface InboxTemplateData {
+    title: string
+    body: string
+}
+
 export type Template<
-    DataObjectType extends EmailTemplateData | TextTemplateData | PushTemplateData =
+    DataObjectType extends
         | EmailTemplateData
         | TextTemplateData
-        | PushTemplateData,
+        | PushTemplateData
+        | InboxTemplateData =
+        | EmailTemplateData
+        | TextTemplateData
+        | PushTemplateData
+        | InboxTemplateData,
 > = {
     id: UUID
     campaign_id: UUID
@@ -738,6 +748,10 @@ export type Template<
     | {
           type: "push"
           data: PushTemplateData
+      }
+    | {
+          type: "inbox"
+          data: InboxTemplateData
       }
 )
 

--- a/console/src/validation/campaign/new-campaign.ts
+++ b/console/src/validation/campaign/new-campaign.ts
@@ -3,13 +3,16 @@ import * as z from "zod"
 export const newCampaignSchema = z
     .object({
         name: z.string().min(1, "Name is required"),
-        channel: z.enum(["email", "sms", "push"]),
+        channel: z.enum(["email", "sms", "push", "inbox"]),
         transactional: z.boolean(),
         subscription_id: z.string().optional(),
     })
-    .refine((data) => data.transactional || (data.subscription_id && data.subscription_id.length > 0), {
-        message: "Subscription is required for non-transactional campaigns",
-        path: ["subscription_id"],
-    })
+    .refine(
+        (data) => data.transactional || (data.subscription_id && data.subscription_id.length > 0),
+        {
+            message: "Subscription is required for non-transactional campaigns",
+            path: ["subscription_id"],
+        },
+    )
 
 export type NewCampaignFormValues = z.infer<typeof newCampaignSchema>

--- a/console/src/validation/campaign/template/data.ts
+++ b/console/src/validation/campaign/template/data.ts
@@ -39,3 +39,8 @@ export const pushTemplateDataSchema = z.object({
     url: z.string().default(""),
     custom: z.record(z.string(), z.unknown()).default({}),
 })
+
+export const inboxTemplateDataSchema = z.object({
+    title: z.string().default(""),
+    body: z.string().default(""),
+})

--- a/console/src/validation/campaign/template/inbox/setup.ts
+++ b/console/src/validation/campaign/template/inbox/setup.ts
@@ -1,0 +1,6 @@
+import * as z from "zod"
+
+export const inboxSetupFormSchema = z.object({
+    title: z.string("Title is required").min(1, "Title is required"),
+    body: z.string().default(""),
+})

--- a/console/src/views/broadcast/BroadcastMessagePreview.tsx
+++ b/console/src/views/broadcast/BroadcastMessagePreview.tsx
@@ -120,10 +120,6 @@ export function BroadcastMessagePreview({ campaignId, defaultUser }: BroadcastMe
     )
 }
 
-// ---------------------------------------------------------------------------
-// Email Preview
-// ---------------------------------------------------------------------------
-
 function EmailBroadcastPreview({
     campaign: _campaign,
     template,
@@ -237,10 +233,6 @@ function EmailBroadcastPreview({
     )
 }
 
-// ---------------------------------------------------------------------------
-// SMS Preview
-// ---------------------------------------------------------------------------
-
 function SmsBroadcastPreview({
     template,
     user,
@@ -300,10 +292,6 @@ function SmsBroadcastPreview({
     )
 }
 
-// ---------------------------------------------------------------------------
-// Push Preview
-// ---------------------------------------------------------------------------
-
 function PushBroadcastPreview({ template, user }: { template: Template; user: User | null }) {
     const rawTitle = template.data.title ?? ""
     const rawBody = template.data.body ?? ""
@@ -335,10 +323,6 @@ function PushBroadcastPreview({ template, user }: { template: Template; user: Us
         </div>
     )
 }
-
-// ---------------------------------------------------------------------------
-// Inbox Preview
-// ---------------------------------------------------------------------------
 
 function InboxBroadcastPreview({
     template,

--- a/console/src/views/broadcast/BroadcastMessagePreview.tsx
+++ b/console/src/views/broadcast/BroadcastMessagePreview.tsx
@@ -10,6 +10,7 @@ import { Render } from "@/renderTemplates"
 import { compileEmail } from "@/views/campaign/template/mail/editor/codeEditor/compileEmail"
 import { getSystemPreviewProps } from "@/views/campaign/template/mail/editor/variableScope"
 import { UserSelection } from "@/views/campaign/template/UserSelection"
+import { InboxNotificationCenter } from "@/views/campaign/template/inbox/InboxNotificationCenter"
 
 interface BroadcastMessagePreviewProps {
     campaignId: UUID
@@ -107,6 +108,13 @@ export function BroadcastMessagePreview({ campaignId, defaultUser }: BroadcastMe
             )}
             {campaign.channel === "push" && (
                 <PushBroadcastPreview template={template} user={selectedUser} />
+            )}
+            {campaign.channel === "inbox" && (
+                <InboxBroadcastPreview
+                    template={template}
+                    user={selectedUser}
+                    appName={project.name}
+                />
             )}
         </div>
     )
@@ -326,4 +334,26 @@ function PushBroadcastPreview({ template, user }: { template: Template; user: Us
             </div>
         </div>
     )
+}
+
+// ---------------------------------------------------------------------------
+// Inbox Preview
+// ---------------------------------------------------------------------------
+
+function InboxBroadcastPreview({
+    template,
+    user,
+    appName,
+}: {
+    template: Template
+    user: User | null
+    appName: string
+}) {
+    const rawTitle = template.data.title ?? ""
+    const rawBody = template.data.body ?? ""
+
+    const title = user ? Render(rawTitle, { user }) : rawTitle
+    const body = user ? Render(rawBody, { user }) : rawBody
+
+    return <InboxNotificationCenter title={title} body={body} appName={appName} />
 }

--- a/console/src/views/broadcast/Broadcasts.tsx
+++ b/console/src/views/broadcast/Broadcasts.tsx
@@ -10,6 +10,7 @@ import {
     Mail,
     Smartphone,
     MessageSquareDot,
+    Inbox,
     CalendarClock,
 } from "lucide-react"
 
@@ -39,8 +40,9 @@ import { Badge } from "@/components/ui/badge"
 
 const channelIcons: Record<ChannelType, typeof Mail> = {
     email: Mail,
-    text: Smartphone,
+    sms: Smartphone,
     push: MessageSquareDot,
+    inbox: Inbox,
 }
 
 function getStateBadge(state: BroadcastState, t: (key: string, fallback?: string) => string) {

--- a/console/src/views/broadcast/CreateBroadcastDialog.tsx
+++ b/console/src/views/broadcast/CreateBroadcastDialog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
-import { Radio, Mail, Smartphone, MessageSquareDot, Info, Calendar } from "lucide-react"
+import { Radio, Mail, Smartphone, MessageSquareDot, Inbox, Info, Calendar } from "lucide-react"
 
 import { toast } from "sonner"
 
@@ -44,6 +44,7 @@ const channelIcons: Record<ChannelType, typeof Mail> = {
     email: Mail,
     sms: Smartphone,
     push: MessageSquareDot,
+    inbox: Inbox,
 }
 
 interface CreateBroadcastDialogProps {

--- a/console/src/views/broadcast/broadcast-state.tsx
+++ b/console/src/views/broadcast/broadcast-state.tsx
@@ -2,6 +2,7 @@ import {
     Mail,
     Smartphone,
     MessageSquareDot,
+    Inbox,
     Clock,
     CheckCircle2,
     XCircle,
@@ -39,8 +40,9 @@ export function isSentState(state: BroadcastState): boolean {
 
 export const channelIcons: Record<ChannelType, typeof Mail> = {
     email: Mail,
-    text: Smartphone,
+    sms: Smartphone,
     push: MessageSquareDot,
+    inbox: Inbox,
 }
 
 export const stateConfig: Record<

--- a/console/src/views/campaign/Campaigns.tsx
+++ b/console/src/views/campaign/Campaigns.tsx
@@ -10,6 +10,7 @@ import {
     Mail,
     Smartphone,
     MessageSquareDot,
+    Inbox,
     MoreHorizontal,
     Copy,
     Archive,
@@ -51,6 +52,7 @@ const channelIcons: Record<ChannelType, typeof Mail> = {
     email: Mail,
     sms: Smartphone,
     push: MessageSquareDot,
+    inbox: Inbox,
 }
 
 function formatDelivery(delivery: CampaignDelivery) {

--- a/console/src/views/campaign/ChannelTag.tsx
+++ b/console/src/views/campaign/ChannelTag.tsx
@@ -1,5 +1,5 @@
 import type { ChannelType } from "../../types"
-import { EmailIcon, InboxIcon, PushIcon, TextIcon } from "../../components/icons"
+import { Mail, Smartphone, MessageSquareDot, Inbox } from "lucide-react"
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import { useTranslation } from "react-i18next"
 
@@ -8,15 +8,19 @@ interface ChannelTagParams {
     showIcon?: boolean
 }
 
-export function ChannelIcon({ channel }: Pick<ChannelTagParams, "channel">) {
-    const icons = {
-        email: EmailIcon,
-        sms: TextIcon,
-        push: PushIcon,
-        inbox: InboxIcon,
-    }
-    const Icon = icons[channel]
-    return <Icon />
+const channelIcons: Record<ChannelType, typeof Mail> = {
+    email: Mail,
+    sms: Smartphone,
+    push: MessageSquareDot,
+    inbox: Inbox,
+}
+
+export function ChannelIcon({
+    channel,
+    className = "h-4 w-4",
+}: Pick<ChannelTagParams, "channel"> & { className?: string }) {
+    const Icon = channelIcons[channel]
+    return <Icon className={className} />
 }
 
 export default function ChannelTag({
@@ -34,8 +38,8 @@ export default function ChannelTag({
     }
 
     return (
-        <Badge variant="secondary" {...params}>
-            {showIcon && <ChannelIcon channel={channel} />}
+        <Badge variant="secondary" className="gap-1" {...params}>
+            {showIcon && <ChannelIcon channel={channel} className="h-3.5 w-3.5" />}
             {title[channel]}
         </Badge>
     )

--- a/console/src/views/campaign/ChannelTag.tsx
+++ b/console/src/views/campaign/ChannelTag.tsx
@@ -1,5 +1,5 @@
 import type { ChannelType } from "../../types"
-import { EmailIcon, PushIcon, TextIcon } from "../../components/icons"
+import { EmailIcon, InboxIcon, PushIcon, TextIcon } from "../../components/icons"
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import { useTranslation } from "react-i18next"
 
@@ -13,6 +13,7 @@ export function ChannelIcon({ channel }: Pick<ChannelTagParams, "channel">) {
         email: EmailIcon,
         sms: TextIcon,
         push: PushIcon,
+        inbox: InboxIcon,
     }
     const Icon = icons[channel]
     return <Icon />
@@ -29,6 +30,7 @@ export default function ChannelTag({
         email: t("email"),
         sms: t("sms"),
         push: t("push"),
+        inbox: t("inbox"),
     }
 
     return (

--- a/console/src/views/campaign/CreateCampaign.tsx
+++ b/console/src/views/campaign/CreateCampaign.tsx
@@ -4,7 +4,7 @@ import { ProjectContext } from "@/contexts"
 import { useContext, useState } from "react"
 import type { ReactNode } from "react"
 
-import { ArrowRight, Mail, MessageSquareDot, PlusIcon, Smartphone } from "lucide-react"
+import { ArrowRight, Inbox, Mail, MessageSquareDot, PlusIcon, Smartphone } from "lucide-react"
 import type { ChannelType } from "@/types"
 
 import {
@@ -88,6 +88,13 @@ export function CreateCampaign({ open = false, onBeforeCreate, trigger }: Create
             icon: <MessageSquareDot strokeWidth={2} />,
             title: t("channels.push.title"),
             description: t("channels.push.description"),
+        },
+        {
+            key: "inbox",
+            color: "bg-amber-50 text-amber-600",
+            icon: <Inbox strokeWidth={2} />,
+            title: t("channels.inbox.title"),
+            description: t("channels.inbox.description"),
         },
     ]
 

--- a/console/src/views/campaign/NewCampaign.tsx
+++ b/console/src/views/campaign/NewCampaign.tsx
@@ -3,7 +3,7 @@ import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useNavigate, useParams } from "react-router"
 import { useTranslation } from "react-i18next"
-import { Mail, MessageSquareDot, Smartphone } from "lucide-react"
+import { Inbox, Info, Mail, MessageSquareDot, Smartphone } from "lucide-react"
 import { toast } from "sonner"
 
 import api from "@/api"
@@ -31,6 +31,7 @@ import {
     emailTemplateDataSchema,
     textTemplateDataSchema,
     pushTemplateDataSchema,
+    inboxTemplateDataSchema,
 } from "@/validation/campaign/template/data"
 
 type ChannelConfig = {
@@ -41,7 +42,7 @@ type ChannelConfig = {
 }
 
 function isChannelType(value?: string): value is ChannelType {
-    return value === "email" || value === "sms" || value === "push"
+    return value === "email" || value === "sms" || value === "push" || value === "inbox"
 }
 
 export default function NewCampaign() {
@@ -54,6 +55,8 @@ export default function NewCampaign() {
     const [isCreating, setIsCreating] = useState(false)
 
     const channel = isChannelType(channelParam) ? channelParam : null
+    // Inbox campaigns have no subscription model — they are always transactional.
+    const isInbox = channel === "inbox"
 
     const form = useForm<NewCampaignFormValues>({
         resolver: zodResolver(newCampaignSchema),
@@ -61,7 +64,7 @@ export default function NewCampaign() {
         defaultValues: {
             name: "",
             channel: channel ?? "email",
-            transactional: false,
+            transactional: isInbox,
             subscription_id: "",
         },
     })
@@ -130,6 +133,12 @@ export default function NewCampaign() {
                 icon: <MessageSquareDot className="h-4 w-4" />,
                 colorClass: "bg-purple-50 text-purple-600",
             },
+            inbox: {
+                title: t("channels.inbox.title"),
+                description: t("channels.inbox.description"),
+                icon: <Inbox className="h-4 w-4" />,
+                colorClass: "bg-amber-50 text-amber-600",
+            },
         }
 
         return config[channel]
@@ -141,6 +150,7 @@ export default function NewCampaign() {
         email: emailTemplateDataSchema,
         sms: textTemplateDataSchema,
         push: pushTemplateDataSchema,
+        inbox: inboxTemplateDataSchema,
     } as const
 
     async function createCampaign(data: NewCampaignFormValues) {
@@ -162,8 +172,9 @@ export default function NewCampaign() {
                     body: {
                         name: data.name.trim(),
                         channel,
-                        transactional: data.transactional,
-                        subscription_id: data.transactional ? undefined : data.subscription_id,
+                        transactional: isInbox ? true : data.transactional,
+                        subscription_id:
+                            isInbox || data.transactional ? undefined : data.subscription_id,
                     },
                 },
             )
@@ -277,37 +288,51 @@ export default function NewCampaign() {
                         </Field>
                     </FieldGroup>
 
-                    <Controller
-                        control={form.control}
-                        name="transactional"
-                        render={({ field }) => (
-                            <div className="flex items-center justify-between rounded-md border p-3">
-                                <div className="space-y-1">
-                                    <Label htmlFor="transactional-toggle">
-                                        {t("campaign.transactional", "Transactional")}
-                                    </Label>
-                                    <p className="text-sm text-muted-foreground">
-                                        {t(
-                                            "campaign.transactional.help",
-                                            "When enabled, subscription preference is ignored.",
-                                        )}
-                                    </p>
-                                </div>
-                                <Switch
-                                    id="transactional-toggle"
-                                    checked={field.value}
-                                    onCheckedChange={(checked) => {
-                                        field.onChange(checked)
-                                        if (checked) {
-                                            form.setValue("subscription_id", "")
-                                        }
-                                    }}
-                                />
-                            </div>
-                        )}
-                    />
+                    {isInbox && (
+                        <div className="flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+                            <Info aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+                            <span>
+                                {t(
+                                    "campaign.inbox.transactional_note",
+                                    "Inbox campaigns are always delivered to the recipient's inbox and do not use subscription preferences.",
+                                )}
+                            </span>
+                        </div>
+                    )}
 
-                    {!isTransactional && (
+                    {!isInbox && (
+                        <Controller
+                            control={form.control}
+                            name="transactional"
+                            render={({ field }) => (
+                                <div className="flex items-center justify-between rounded-md border p-3">
+                                    <div className="space-y-1">
+                                        <Label htmlFor="transactional-toggle">
+                                            {t("campaign.transactional", "Transactional")}
+                                        </Label>
+                                        <p className="text-sm text-muted-foreground">
+                                            {t(
+                                                "campaign.transactional.help",
+                                                "When enabled, subscription preference is ignored.",
+                                            )}
+                                        </p>
+                                    </div>
+                                    <Switch
+                                        id="transactional-toggle"
+                                        checked={field.value}
+                                        onCheckedChange={(checked) => {
+                                            field.onChange(checked)
+                                            if (checked) {
+                                                form.setValue("subscription_id", "")
+                                            }
+                                        }}
+                                    />
+                                </div>
+                            )}
+                        />
+                    )}
+
+                    {!isInbox && !isTransactional && (
                         <FieldGroup>
                             <Field className="gap-2">
                                 <FieldLabel htmlFor="subscription-select">

--- a/console/src/views/campaign/template/channels.ts
+++ b/console/src/views/campaign/template/channels.ts
@@ -4,6 +4,7 @@ import type { Campaign, ChannelType, Template } from "@/types"
 import { EmailContentPreview, EmailForm, EmailFormControl, EmailPreview } from "./mail/Setup"
 import { TextForm, TextFormControl, TextPreview } from "./text/Setup"
 import { PushForm, PushFormControl, PushPreview } from "./push/Setup"
+import { InboxForm, InboxFormControl, InboxPreview } from "./inbox/Setup"
 export interface ChannelConfig<T extends FieldValues> {
     form: (campaign: Campaign, template?: Template) => UseFormReturn<T>
     FormControl: ComponentType<{ campaign: Campaign; form: UseFormReturn<T>; disabled?: boolean }>
@@ -30,5 +31,11 @@ export const channels: Partial<Record<ChannelType, ChannelConfig<any>>> = {
         FormControl: PushFormControl,
         Preview: PushPreview,
         ContentPreview: PushPreview,
+    },
+    inbox: {
+        form: InboxForm,
+        FormControl: InboxFormControl,
+        Preview: InboxPreview,
+        ContentPreview: InboxPreview,
     },
 }

--- a/console/src/views/campaign/template/inbox/InboxNotificationCenter.tsx
+++ b/console/src/views/campaign/template/inbox/InboxNotificationCenter.tsx
@@ -1,0 +1,101 @@
+import { Inbox } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+interface InboxNotificationCenterProps {
+    /** Rendered message title (variables already substituted). */
+    title: string
+    /** Rendered message body (variables already substituted). */
+    body: string
+    /** App / project name shown in the header. */
+    appName?: string
+}
+
+// A faux in-app inbox / notification center. The campaign message renders as the
+// top, unread item; the dimmed rows beneath it exist purely to convey that the
+// message lands inside a list. Mirrors the message layout used on the user
+// detail inbox tab (bold title, muted body) so previews stay consistent.
+export function InboxNotificationCenter({ title, body, appName }: InboxNotificationCenterProps) {
+    const { t } = useTranslation()
+    const time = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+
+    const placeholders = [
+        {
+            title: t("campaign.setup.channels.inbox.sample.title_1", "Welcome aboard"),
+            body: t(
+                "campaign.setup.channels.inbox.sample.body_1",
+                "Thanks for joining. Here are a few tips to get you started.",
+            ),
+        },
+        {
+            title: t("campaign.setup.channels.inbox.sample.title_2", "Your weekly summary"),
+            body: t(
+                "campaign.setup.channels.inbox.sample.body_2",
+                "A recap of everything that happened this week.",
+            ),
+        },
+    ]
+
+    return (
+        <div className="mx-auto w-full max-w-md">
+            <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl">
+                {/* Header */}
+                <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+                    <div className="flex items-center gap-2">
+                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gray-900">
+                            <Inbox className="h-4 w-4 text-white" />
+                        </div>
+                        <span className="text-sm font-semibold text-gray-900">
+                            {appName || t("inbox", "Inbox")}
+                        </span>
+                    </div>
+                    <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs font-medium text-white">
+                        1 {t("campaign.setup.channels.inbox.new", "new")}
+                    </span>
+                </div>
+
+                {/* Active (campaign) message — unread */}
+                <div className="relative flex gap-3 bg-blue-50/60 px-4 py-3">
+                    <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-2">
+                            <span className="truncate text-sm font-semibold text-gray-900">
+                                {title || (
+                                    <span className="italic text-gray-400">
+                                        {t("campaign.setup.channels.inbox.no_title", "No title")}
+                                    </span>
+                                )}
+                            </span>
+                            <span className="shrink-0 text-xs text-gray-500">{time}</span>
+                        </div>
+                        {body && (
+                            <p className="mt-0.5 line-clamp-3 text-sm text-gray-600">{body}</p>
+                        )}
+                    </div>
+                </div>
+
+                {/* Dimmed placeholder messages for context */}
+                {placeholders.map((message, index) => (
+                    <div
+                        key={index}
+                        className="flex gap-3 border-t border-gray-100 px-4 py-3 opacity-50"
+                    >
+                        <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-transparent" />
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2">
+                                <span className="truncate text-sm font-medium text-gray-700">
+                                    {message.title}
+                                </span>
+                                <span className="shrink-0 text-xs text-gray-400">
+                                    {index === 0 ? "1h" : "1d"}
+                                </span>
+                            </div>
+                            <p className="mt-0.5 line-clamp-1 text-sm text-gray-500">
+                                {message.body}
+                            </p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/console/src/views/campaign/template/inbox/InboxNotificationCenter.tsx
+++ b/console/src/views/campaign/template/inbox/InboxNotificationCenter.tsx
@@ -36,60 +36,62 @@ export function InboxNotificationCenter({ title, body, appName }: InboxNotificat
     ]
 
     return (
-        <div className="mx-auto w-full max-w-md">
-            <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl">
+        <div className="w-full">
+            <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
                 {/* Header */}
-                <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+                <div className="flex items-center justify-between border-b px-4 py-3">
                     <div className="flex items-center gap-2">
-                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gray-900">
-                            <Inbox className="h-4 w-4 text-white" />
-                        </div>
-                        <span className="text-sm font-semibold text-gray-900">
+                        <Inbox className="h-4 w-4 text-muted-foreground" />
+                        <span className="text-sm font-semibold text-foreground">
                             {appName || t("inbox", "Inbox")}
                         </span>
                     </div>
-                    <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs font-medium text-white">
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
                         1 {t("campaign.setup.channels.inbox.new", "new")}
                     </span>
                 </div>
 
                 {/* Active (campaign) message — unread */}
-                <div className="relative flex gap-3 bg-blue-50/60 px-4 py-3">
-                    <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+                <div className="relative flex gap-3 bg-muted/40 px-4 py-3">
+                    <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
                     <div className="min-w-0 flex-1">
                         <div className="flex items-center justify-between gap-2">
-                            <span className="truncate text-sm font-semibold text-gray-900">
+                            <span className="truncate text-sm font-semibold text-foreground">
                                 {title || (
-                                    <span className="italic text-gray-400">
+                                    <span className="italic text-muted-foreground">
                                         {t("campaign.setup.channels.inbox.no_title", "No title")}
                                     </span>
                                 )}
                             </span>
-                            <span className="shrink-0 text-xs text-gray-500">{time}</span>
+                            <span className="shrink-0 text-xs text-muted-foreground">{time}</span>
                         </div>
                         {body && (
-                            <p className="mt-0.5 line-clamp-3 text-sm text-gray-600">{body}</p>
+                            <p className="mt-0.5 line-clamp-3 whitespace-pre-line text-sm text-muted-foreground">
+                                {body}
+                            </p>
                         )}
                     </div>
                 </div>
 
-                {/* Dimmed placeholder messages for context */}
+                {/* Placeholder messages, blurred — they only convey that the campaign
+                    message lands inside a list, not real content. */}
                 {placeholders.map((message, index) => (
                     <div
                         key={index}
-                        className="flex gap-3 border-t border-gray-100 px-4 py-3 opacity-50"
+                        aria-hidden
+                        className="flex select-none gap-3 border-t px-4 py-3 opacity-60 blur-[2px]"
                     >
                         <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-transparent" />
                         <div className="min-w-0 flex-1">
                             <div className="flex items-center justify-between gap-2">
-                                <span className="truncate text-sm font-medium text-gray-700">
+                                <span className="truncate text-sm font-medium text-foreground">
                                     {message.title}
                                 </span>
-                                <span className="shrink-0 text-xs text-gray-400">
+                                <span className="shrink-0 text-xs text-muted-foreground">
                                     {index === 0 ? "1h" : "1d"}
                                 </span>
                             </div>
-                            <p className="mt-0.5 line-clamp-1 text-sm text-gray-500">
+                            <p className="mt-0.5 line-clamp-1 text-sm text-muted-foreground">
                                 {message.body}
                             </p>
                         </div>

--- a/console/src/views/campaign/template/inbox/Setup.tsx
+++ b/console/src/views/campaign/template/inbox/Setup.tsx
@@ -1,0 +1,236 @@
+import { Controller, useForm, type UseFormReturn } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import type { Campaign, Template, User, Locale } from "@/types"
+import { Rocket } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { useContext, useState, useEffect } from "react"
+import { ProjectContext, TemplateContext } from "@/contexts"
+import { useNavigate } from "react-router"
+import { Button } from "@/components/ui/button"
+import api from "@/api"
+import type { z } from "zod"
+
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
+import { TemplateInput } from "@/components/ui/template-input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Render } from "@/renderTemplates"
+
+import { UserSelection } from "../UserSelection"
+import { useCampaignVariableContext } from "../../CampaignVariableContext"
+import { InboxNotificationCenter } from "./InboxNotificationCenter"
+import { useSendTestInbox } from "./useSendTestInbox"
+
+import { inboxSetupFormSchema } from "@/validation/campaign/template/inbox/setup"
+
+export function InboxForm(_campaign: Campaign, template?: Template) {
+    const formSchema = inboxSetupFormSchema.extend({})
+
+    const defaultValues: z.infer<typeof inboxSetupFormSchema> = {
+        title: "",
+        body: "",
+    }
+
+    if (template && template.type == "inbox") {
+        defaultValues.title = template.data.title
+        defaultValues.body = template.data.body
+    }
+
+    return useForm({
+        resolver: zodResolver(formSchema),
+        defaultValues,
+    })
+}
+
+interface InboxFormControlProps {
+    campaign: Campaign
+    form: UseFormReturn<z.infer<typeof inboxSetupFormSchema>>
+    disabled?: boolean
+}
+
+export function InboxFormControl({ form, disabled = false }: InboxFormControlProps) {
+    const { t } = useTranslation()
+    const { variableGroups } = useCampaignVariableContext()
+
+    return (
+        <FieldGroup className="mt-7">
+            <Controller
+                name="title"
+                control={form.control}
+                render={({ field, fieldState }) => (
+                    <Field data-invalid={fieldState.invalid} className="gap-2">
+                        <FieldLabel htmlFor="inbox-title">
+                            {t("campaign.setup.channels.inbox.title.label", "Title")}
+                        </FieldLabel>
+                        <TemplateInput
+                            id="inbox-title"
+                            value={field.value}
+                            onChange={field.onChange}
+                            placeholder={t(
+                                "campaign.setup.channels.inbox.title.placeholder",
+                                "Message title",
+                            )}
+                            disabled={disabled}
+                            variables={variableGroups}
+                        />
+                        {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+                    </Field>
+                )}
+            />
+            <Controller
+                name="body"
+                control={form.control}
+                render={({ field, fieldState }) => (
+                    <Field data-invalid={fieldState.invalid} className="gap-2">
+                        <FieldLabel htmlFor="inbox-body">
+                            {t("campaign.setup.channels.inbox.body.label", "Body")}
+                        </FieldLabel>
+                        <TemplateInput
+                            id="inbox-body"
+                            value={field.value}
+                            onChange={field.onChange}
+                            placeholder={t(
+                                "campaign.setup.channels.inbox.body.placeholder",
+                                "Message body shown to the recipient",
+                            )}
+                            disabled={disabled}
+                            variables={variableGroups}
+                        />
+                        {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+                    </Field>
+                )}
+            />
+        </FieldGroup>
+    )
+}
+
+const sampleMessages = [
+    ["Welcome to the team", "We're glad you're here. Take a look around to get started."],
+    ["Your order has shipped", "Track your package and see the estimated delivery date."],
+    ["New feature available", "We've added something we think you'll love. Check it out."],
+    ["Action needed", "Please review your account details to keep everything up to date."],
+]
+
+function sampleMessage() {
+    const index = Math.floor(Math.random() * sampleMessages.length)
+    return sampleMessages[index]
+}
+
+export interface InboxSetupProps {
+    campaign: Campaign
+    form: UseFormReturn<z.infer<typeof inboxSetupFormSchema>>
+    edit?: boolean
+}
+
+export function InboxPreview({ campaign, form, edit = false }: InboxSetupProps) {
+    const [project] = useContext(ProjectContext)
+    const [template, setTemplate] = useContext(TemplateContext)
+    const { t } = useTranslation()
+    const [selectedUser, setSelectedUser] = useState<User | null>(null)
+    const [selectedLocale, setSelectedLocale] = useState(template.locale)
+    const [locales, setLocales] = useState<Locale[]>([])
+    const navigate = useNavigate()
+
+    const { sending, handleSendTest } = useSendTestInbox({ projectId: project.id })
+
+    useEffect(() => {
+        const fetchLocales = async () => {
+            if (project?.id) {
+                const result = await api.locales.search(project.id, { limit: 100 })
+                setLocales(result.results)
+            }
+        }
+        fetchLocales()
+    }, [project?.id])
+
+    const [[placeholderTitle, placeholderBody]] = useState(() => sampleMessage())
+    const rawTitle = form.watch("title") || placeholderTitle
+    const rawBody = form.watch("body") || placeholderBody
+
+    const title = selectedUser ? Render(rawTitle, { user: selectedUser }) : rawTitle
+    const body = selectedUser ? Render(rawBody, { user: selectedUser }) : rawBody
+
+    const handleEditTemplate = () => {
+        navigate(`/projects/${project?.id}/campaigns/${campaign.id}/templates/${template.id}`)
+    }
+
+    const handleLocaleChange = async (locale: string) => {
+        setSelectedLocale(locale)
+        const newTemplate = campaign.templates.find((t) => t.locale === locale)
+        if (!newTemplate) {
+            return
+        }
+        setTemplate(newTemplate)
+    }
+
+    return (
+        <>
+            <div className="mb-4 flex items-center justify-between gap-4">
+                <UserSelection
+                    projectId={project?.id}
+                    value={selectedUser}
+                    onChange={setSelectedUser}
+                />
+                {!edit && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div>
+                                <Button
+                                    variant="default"
+                                    size="sm"
+                                    className="h-9 gap-1.5 shrink-0"
+                                    onClick={() => {
+                                        if (selectedUser) {
+                                            handleSendTest(selectedUser, title, body)
+                                        }
+                                    }}
+                                    disabled={sending || !selectedUser}
+                                >
+                                    <Rocket className="h-3.5 w-3.5" />
+                                    {t("send_test_inbox.button", "Send test")}
+                                </Button>
+                            </div>
+                        </TooltipTrigger>
+                        {!selectedUser && (
+                            <TooltipContent>
+                                {t(
+                                    "send_test_inbox.no_user",
+                                    "Select a user to send a test inbox message",
+                                )}
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                )}
+                {edit && (
+                    <div className="flex items-center gap-2">
+                        <Select value={selectedLocale} onValueChange={handleLocaleChange}>
+                            <SelectTrigger className="w-[180px]">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {campaign.templates.map((t) => {
+                                    const locale = locales.find((l) => l.key === t.locale)
+                                    return (
+                                        <SelectItem key={t.id} value={t.locale}>
+                                            {locale?.label || t.locale}
+                                        </SelectItem>
+                                    )
+                                })}
+                            </SelectContent>
+                        </Select>
+                        <Button onClick={handleEditTemplate}>{t("campaign.template.edit")}</Button>
+                    </div>
+                )}
+            </div>
+            <div className="flex w-full flex-1 items-start justify-center pt-4">
+                <InboxNotificationCenter title={title} body={body} appName={project?.name} />
+            </div>
+        </>
+    )
+}

--- a/console/src/views/campaign/template/inbox/Setup.tsx
+++ b/console/src/views/campaign/template/inbox/Setup.tsx
@@ -93,6 +93,7 @@ export function InboxFormControl({ form, disabled = false }: InboxFormControlPro
                         </FieldLabel>
                         <TemplateInput
                             id="inbox-body"
+                            multiline
                             value={field.value}
                             onChange={field.onChange}
                             placeholder={t(

--- a/console/src/views/campaign/template/inbox/useSendTestInbox.ts
+++ b/console/src/views/campaign/template/inbox/useSendTestInbox.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from "react"
+import { toast } from "sonner"
+import type { User } from "@/types"
+import { oapiClient } from "@/oapi/client"
+
+interface UseSendTestInboxOptions {
+    projectId: string
+}
+
+export interface UseSendTestInboxResult {
+    sending: boolean
+    handleSendTest: (user: User, title: string, body: string) => Promise<void>
+}
+
+/**
+ * Sends a test inbox message into the selected user's inbox.
+ *
+ * Inbox messages have no external provider dispatch, so a test is simply a real
+ * inbox message created through the user inbox endpoint — the same path the user
+ * detail inbox tab uses. The title and body should already have their template
+ * variables substituted for the chosen user.
+ */
+export function useSendTestInbox({ projectId }: UseSendTestInboxOptions): UseSendTestInboxResult {
+    const [sending, setSending] = useState(false)
+
+    const handleSendTest = useCallback(
+        async (user: User, title: string, body: string) => {
+            setSending(true)
+            try {
+                const { error } = await oapiClient.POST(
+                    "/api/admin/projects/{projectID}/subjects/users/{userID}/inbox",
+                    {
+                        params: { path: { projectID: projectId, userID: user.id } },
+                        body: {
+                            channel: "inbox",
+                            content: {
+                                title: title.trim(),
+                                body: body.trim() || undefined,
+                            },
+                            tags: ["test"],
+                            priority: 3,
+                        },
+                    },
+                )
+
+                if (error) {
+                    const detail =
+                        typeof (error as Record<string, unknown>)?.detail === "string"
+                            ? ((error as Record<string, unknown>).detail as string)
+                            : null
+                    toast.error(detail || "Failed to send test inbox message")
+                    return
+                }
+
+                toast.success(`Test inbox message sent to ${user.email}`)
+            } catch {
+                toast.error("Failed to send test inbox message")
+            } finally {
+                setSending(false)
+            }
+        },
+        [projectId],
+    )
+
+    return { sending, handleSendTest }
+}

--- a/internal/pubsub/consumer/campaigns_render.go
+++ b/internal/pubsub/consumer/campaigns_render.go
@@ -162,7 +162,7 @@ func renderCampaignInboxMessages(ctx context.Context, logger *zap.Logger, mgmt *
 		if err != nil {
 			return nil, Permanent(err)
 		}
-	case providers.ChannelSMS, providers.ChannelPush:
+	case providers.ChannelSMS, providers.ChannelPush, providers.ChannelInbox:
 		var err error
 		template.Data, err = render.RenderJSON(template.Data, data)
 		if err != nil {
@@ -170,6 +170,18 @@ func renderCampaignInboxMessages(ctx context.Context, logger *zap.Logger, mgmt *
 		}
 	default:
 		return nil, Permanentf("unsupported campaign channel: %s", campaign.Channel)
+	}
+
+	// Inbox campaigns have no external provider dispatch and no sender
+	// identity. The rendered template data ({title, body}) is stored directly
+	// as the inbox message content, mirroring how a message created from the
+	// user inbox tab is shaped.
+	if channel == providers.ChannelInbox {
+		return []renderedCampaignInboxMessage{{
+			Channel:         channel,
+			TemplateID:      template.ID,
+			RenderedPayload: template.Data,
+		}}, nil
 	}
 
 	if channel == providers.ChannelPush {


### PR DESCRIPTION
## Summary

Adds **inbox** as a first-class campaign channel alongside email, SMS, and push. Campaigns can now be created for a user's in-app inbox and delivered from a **Journey** or a **Broadcast** (enterprise).

The backend was already ~95% ready — `inbox` is a valid `Channel` everywhere and the send → inbox-row → dispatch pipeline already short-circuits provider dispatch for the inbox channel. The only gap was the campaign render switch, which rejected `inbox`.

## Console

- Extend `ChannelType` and the `Template` data union with an `inbox` arm (`title`, `body`).
- New `template/inbox/Setup.tsx` editor reusing `TemplateInput` variable support. Title + body mirror the inbox channel on the **user inbox tab** (per request).
- Reusable **`InboxNotificationCenter`** preview rendering an in-app inbox / notification center (campaign message as the top unread item over dimmed context rows), styled after the user-detail inbox. Reused by the editor preview, campaign-list thumbnails (`preview.tsx`), and the broadcast preview (`BroadcastMessagePreview.tsx`).
- **Send test** delivers a real message into the selected user's inbox via the existing user-inbox endpoint (inbox has no external provider dispatch).
- Registered in the channel registry (`channels.ts`), `CreateCampaign`, and `NewCampaign`. Inbox campaigns are **transactional-only** (no subscription model) — the subscription/transactional controls are replaced with an info note.
- Added `inbox` to the broadcast/campaign channel-icon maps, and fixed a pre-existing `text` → `sms` icon-map bug along the way.
- Journey and Broadcast pick up the new channel automatically (shared `ChannelIcon` / `Preview` / icon maps).

## Backend

- Handle `providers.ChannelInbox` in `campaigns_render.go`: render the template JSON and store `{title, body}` directly as the inbox message content, with no sender identity or provider lookup.

## Verification

- `go build` + `go vet` pass on the consumer package.
- New console files typecheck and lint clean. (The repo has ~123 pre-existing `tsc` union-access errors; this branch only repeats that same pattern in the inbox preview branches — identical to the existing `push` branch — and removes 3 pre-existing icon-map errors.)
- Not yet exercised: full `vite build` and manual click-through of the running app.

## Notes for reviewers

- Inbox content is intentionally just **title + body** to match the user inbox tab. CTA/image were left out of v1.
- The inbox preview branches in `preview.tsx` / `BroadcastMessagePreview.tsx` follow the existing (un-discriminated) union-access pattern used by the other channels rather than refactoring discrimination, for consistency.