### PR TITLE
feat(journeys): add list entry/leave trigger

### DIFF
--- a/console/src/oapi/management.generated.ts
+++ b/console/src/oapi/management.generated.ts
@@ -2581,37 +2581,83 @@ export interface components {
          * @enum {string}
          */
         JourneyStepType: "entrance" | "exit" | "delay" | "action" | "campaign" | "gate" | "experiment" | "sticky" | "balancer" | "update" | "event" | "schedule";
-        /** @description Data for entrance step - entry point into journey */
+        /** @description Data for entrance step - entry point into journey. Tagged union: `trigger` selects the kind and the matching sub-object (event, scheduled or list) carries its fields. `concurrent` and `multiple` apply to every kind. `none` is an API/manually triggered entrance with no sub-object. */
         EntranceStepData: {
             /**
-             * @description Trigger type for entrance
+             * @description Selects which trigger sub-object is active
              * @example event
              * @enum {string}
              */
-            trigger?: "none" | "event";
-            /**
-             * @description Event name that triggers entrance
-             * @example user_signup
-             */
-            event_name?: string;
-            /** @description Rule for filtering events */
-            rule?: {
-                [key: string]: unknown;
-            };
-            /** @description Rule for filtering users (used with organization events) */
-            user_rule?: {
-                [key: string]: unknown;
-            };
-            /**
-             * @description Allow multiple entries
-             * @example false
-             */
-            multiple?: boolean;
+            trigger: "none" | "event" | "scheduled" | "list";
             /**
              * @description Allow concurrent journey runs
              * @example false
              */
             concurrent?: boolean;
+            /**
+             * @description Allow re-entry after a previous run completed
+             * @example false
+             */
+            multiple?: boolean;
+            event?: components["schemas"]["EntranceEventTrigger"];
+            scheduled?: components["schemas"]["EntranceScheduledTrigger"];
+            list?: components["schemas"]["EntranceListTrigger"];
+        };
+        /** @description Enters the user when a matching custom event is received */
+        EntranceEventTrigger: {
+            /**
+             * @description Event name that triggers entrance
+             * @example user_signup
+             */
+            name: string;
+            /** @description Optional condition evaluated against the event data */
+            rule?: {
+                [key: string]: unknown;
+            };
+            /** @description Optional filter for organization members */
+            user_rule?: {
+                [key: string]: unknown;
+            };
+        };
+        /** @description Enters the user when a schedule offset fires */
+        EntranceScheduledTrigger: {
+            /**
+             * @description Scheduled event name that triggers entrance
+             * @example scheduled.weekly_digest
+             */
+            name: string;
+            /**
+             * Format: uuid
+             * @description Schedule offset that fires the entrance
+             */
+            offset_id?: string;
+            /** @description Optional condition evaluated against the event data */
+            rule?: {
+                [key: string]: unknown;
+            };
+            /** @description Optional filter for organization members */
+            user_rule?: {
+                [key: string]: unknown;
+            };
+        };
+        /** @description Enters the user when they join or leave the referenced list */
+        EntranceListTrigger: {
+            /**
+             * Format: uuid
+             * @description List whose membership changes trigger entrance
+             */
+            id: string;
+            /**
+             * @description Membership change that fires the trigger (default joins)
+             * @example joins
+             * @enum {string}
+             */
+            direction?: "joins" | "leaves";
+            /**
+             * @description Exit the user when they leave the list (joins direction only)
+             * @example false
+             */
+            exit_on_leave?: boolean;
         };
         /** @description Data for exit step - exits user from journey */
         ExitStepData: {

--- a/console/src/views/journey/components/JourneyTriggerSetup.tsx
+++ b/console/src/views/journey/components/JourneyTriggerSetup.tsx
@@ -1,9 +1,16 @@
-import { ArrowRight, CalendarClock, MousePointerClick, Webhook, Zap } from "lucide-react"
+import {
+    ArrowRight,
+    CalendarClock,
+    ListChecks,
+    MousePointerClick,
+    Webhook,
+    Zap,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { cn } from "@/utils"
 
-export type EntranceTrigger = "event" | "scheduled" | "none"
+export type EntranceTrigger = "event" | "scheduled" | "list" | "none"
 
 interface JourneyTriggerSetupProps {
     onSelectTrigger: (trigger: EntranceTrigger) => void
@@ -40,6 +47,17 @@ const triggerOptions: Array<{
             "border-amber-200 bg-amber-50/70 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300",
     },
     {
+        trigger: "list",
+        icon: ListChecks,
+        titleKey: "journey_trigger_list_title",
+        titleFallback: "Start from a list",
+        descriptionKey: "journey_trigger_list_desc",
+        descriptionFallback:
+            "Add users when they join a list, and optionally exit them when they leave it.",
+        className:
+            "border-violet-200 bg-violet-50/70 text-violet-700 dark:border-violet-900 dark:bg-violet-950/30 dark:text-violet-300",
+    },
+    {
         trigger: "none",
         icon: Webhook,
         titleKey: "journey_trigger_api_title",
@@ -74,7 +92,7 @@ export function JourneyTriggerSetup({ onSelectTrigger }: JourneyTriggerSetupProp
                     </p>
                 </div>
 
-                <div className="grid gap-4 lg:grid-cols-3">
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
                     {triggerOptions.map((option) => {
                         const Icon = option.icon
                         return (

--- a/console/src/views/journey/editor/JourneyEditor.utils.ts
+++ b/console/src/views/journey/editor/JourneyEditor.utils.ts
@@ -230,14 +230,28 @@ export function getUpstreamDataKeys(
         const node = nodesById.get(current)
         if (node?.data.data_key) {
             const stepData = node.data.data as Record<string, unknown> | undefined
+            // Entrance steps carry trigger details in nested `event` /
+            // `scheduled` blocks; other step types still expose `event_name` at
+            // the top level, so fall back to that.
+            const eventBlock = stepData?.event as { name?: string } | undefined
+            const scheduledBlock = stepData?.scheduled as
+                | { name?: string; offset_id?: string }
+                | undefined
             result.push({
                 nodeId: node.id,
                 name: node.data.name ?? "",
                 type: node.data.type,
                 data_key: node.data.data_key,
-                event_name: (stepData?.event_name as string) ?? undefined,
+                event_name:
+                    eventBlock?.name ??
+                    scheduledBlock?.name ??
+                    (stepData?.event_name as string) ??
+                    undefined,
                 scheduled_name: (stepData?.scheduled_name as string) ?? undefined,
-                schedule_offset_id: (stepData?.schedule_offset_id as string) ?? undefined,
+                schedule_offset_id:
+                    scheduledBlock?.offset_id ??
+                    (stepData?.schedule_offset_id as string) ??
+                    undefined,
             })
         }
         for (const parent of parentMap.get(current) ?? []) {

--- a/console/src/views/journey/steps/Entrance.tsx
+++ b/console/src/views/journey/steps/Entrance.tsx
@@ -54,27 +54,42 @@ import type { UUID } from "@/types/common"
 
 type ListDirection = "joins" | "leaves"
 
+interface EntranceEventTrigger {
+    name?: string
+    rule?: Rule
+    user_rule?: Rule
+}
+
+interface EntranceScheduledTrigger {
+    name?: string
+    offset_id?: UUID
+    rule?: Rule
+    user_rule?: Rule
+}
+
+interface EntranceListTrigger {
+    id?: UUID
+    direction?: ListDirection
+    exit_on_leave?: boolean
+}
+
 interface EntranceConfig {
     trigger: "none" | "event" | "scheduled" | "list"
 
-    // event based
-    event_name?: string
-    rule?: Rule
     multiple?: boolean
     concurrent?: boolean
 
-    // scheduled based
+    // Exactly one matches `trigger` (none carries no block).
+    event?: EntranceEventTrigger
+    scheduled?: EntranceScheduledTrigger
+    list?: EntranceListTrigger
+
+    // UI-only working state. The backend ignores these but they are preserved
+    // verbatim in the stored step data so the editor can restore its selections.
     scheduled_name?: string
-    schedule_offset_id?: UUID
     schedule_offset?: string
     schedule_offset_direction?: string
-
-    // list based
-    list_id?: UUID
     list_name?: string
-    list_direction?: ListDirection
-    exit_on_leave?: boolean
-
     references?: Array<{ id: UUID; name: string }>
 }
 
@@ -137,11 +152,11 @@ function ScheduledOffsetSelector({
     valueRef.current = value
 
     useEffect(() => {
-        if (!valueRef.current.schedule_offset_id && offsets.length > 0) {
+        if (!valueRef.current.scheduled?.offset_id && offsets.length > 0) {
             const first = offsets[0]
             onChangeRef.current({
                 ...valueRef.current,
-                schedule_offset_id: first.id,
+                scheduled: { ...valueRef.current.scheduled, offset_id: first.id },
                 schedule_offset: first.offset,
                 schedule_offset_direction: first.direction,
             })
@@ -158,11 +173,11 @@ function ScheduledOffsetSelector({
                 projectId={projectId}
                 scheduledId={schedule?.id ?? ("" as UUID)}
                 offsets={offsets}
-                value={value.schedule_offset_id}
+                value={value.scheduled?.offset_id}
                 onChange={(offsetId, offset, direction) => {
                     onChange({
                         ...value,
-                        schedule_offset_id: offsetId,
+                        scheduled: { ...value.scheduled, offset_id: offsetId },
                         schedule_offset: offset,
                         schedule_offset_direction: direction,
                     })
@@ -572,15 +587,13 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
     Describe({
         value: {
             trigger,
-            event_name,
-            rule,
+            event,
+            scheduled,
             scheduled_name,
-            schedule_offset_id,
             schedule_offset,
             schedule_offset_direction,
+            list,
             list_name,
-            list_direction,
-            exit_on_leave,
             references = [],
         },
     }) {
@@ -588,6 +601,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
         const [preferences] = useContext(PreferencesContext)
 
         if (trigger === "event") {
+            const rule = event?.rule
             const hasConditions = rule && isEventWrapper(rule) && !!rule?.children?.length
             return (
                 <div className="space-y-1.5 max-w-[300px]">
@@ -595,7 +609,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                         <Zap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                         <span>
                             {t("entrance_add_everyone_when") + " "}
-                            <strong>{event_name || <>&#8211;</>}</strong>
+                            <strong>{event?.name || <>&#8211;</>}</strong>
                             {t("entrance_occurs")}
                         </span>
                     </div>
@@ -619,7 +633,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                     <CalendarClock className="size-4 shrink-0 text-muted-foreground" />
                     <span>
                         <span className="font-medium">{scheduled_name}</span>
-                        {schedule_offset_id && schedule_offset != null && (
+                        {scheduled?.offset_id && schedule_offset != null && (
                             <span className="text-muted-foreground">
                                 {" "}
                                 {formatOffset(
@@ -634,7 +648,8 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
         }
 
         if (trigger === "list") {
-            const direction = list_direction ?? "joins"
+            const direction = list?.direction ?? "joins"
+            const exit_on_leave = list?.exit_on_leave
             return (
                 <div className="space-y-1.5 max-w-[300px]">
                     <div className="flex items-center gap-1.5 text-sm">
@@ -725,14 +740,17 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
         // Seed sensible defaults for the list trigger: enter on join, and exit
         // the journey when the user leaves the list.
         useEffect(() => {
-            if (value.trigger === "list" && value.list_direction === undefined) {
+            if (value.trigger === "list" && value.list?.direction === undefined) {
                 onChange({
                     ...value,
-                    list_direction: "joins",
-                    exit_on_leave: value.exit_on_leave ?? true,
+                    list: {
+                        ...value.list,
+                        direction: "joins",
+                        exit_on_leave: value.list?.exit_on_leave ?? true,
+                    },
                 })
             }
-        }, [value.trigger, value.list_direction]) // eslint-disable-line react-hooks/exhaustive-deps
+        }, [value.trigger, value.list?.direction]) // eslint-disable-line react-hooks/exhaustive-deps
 
         const handleSearch = useCallback(
             async (query: string): Promise<RulePath[]> => {
@@ -745,15 +763,14 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
         )
 
         const handleEventNameChange = useCallback(
-            (event_name: string) => {
-                const currentRule = value.rule
+            (name: string) => {
+                const currentRule = value.event?.rule
                 const updatedRule = currentRule
-                    ? { ...currentRule, value: event_name }
-                    : createSimpleEventRule(event_name)
+                    ? { ...currentRule, value: name }
+                    : createSimpleEventRule(name)
                 onChange({
                     ...value,
-                    event_name,
-                    rule: updatedRule,
+                    event: { ...value.event, name, rule: updatedRule },
                 })
             },
             [onChange, value],
@@ -784,12 +801,19 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                     <Label className="text-sm font-medium">{t("trigger")}</Label>
                     <Tabs
                         value={value.trigger}
-                        onValueChange={(trigger) =>
+                        onValueChange={(next) => {
+                            const trigger = next as EntranceConfig["trigger"]
+                            // Keep only the active trigger's block so the stored
+                            // data stays a clean oneOf; the backend rejects an
+                            // entrance that carries a foreign trigger block.
                             onChange({
                                 ...value,
-                                trigger: trigger as EntranceConfig["trigger"],
+                                trigger,
+                                event: trigger === "event" ? value.event : undefined,
+                                scheduled: trigger === "scheduled" ? value.scheduled : undefined,
+                                list: trigger === "list" ? value.list : undefined,
                             })
-                        }
+                        }}
                     >
                         <TabsList className="w-full">
                             {triggers.map((key) => {
@@ -812,24 +836,27 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                                 <span className="text-destructive">*</span>
                             </Label>
                             <EventNameCombobox
-                                value={value.event_name ?? ""}
+                                value={value.event?.name ?? ""}
                                 onChange={handleEventNameChange}
                                 onSearch={handleSearch}
                             />
                         </div>
-                        {value.event_name && (
+                        {value.event?.name && (
                             <RuleBuilder
-                                rule={value.rule ?? createSimpleEventRule(value.event_name)}
+                                rule={value.event.rule ?? createSimpleEventRule(value.event.name)}
                                 setRule={(rule) =>
                                     onChange({
                                         ...value,
-                                        rule: {
-                                            ...rule,
-                                            value: value.event_name,
+                                        event: {
+                                            ...value.event,
+                                            rule: {
+                                                ...rule,
+                                                value: value.event?.name,
+                                            },
                                         },
                                     })
                                 }
-                                eventName={value.event_name}
+                                eventName={value.event.name}
                                 headerPrefix={t("entrance_matching")}
                             />
                         )}
@@ -886,10 +913,13 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                                     onChange({
                                         ...value,
                                         scheduled_name,
-                                        schedule_offset_id: undefined,
-                                        event_name: scheduled_name
-                                            ? `scheduled.${scheduled_name}`
-                                            : undefined,
+                                        scheduled: {
+                                            ...value.scheduled,
+                                            name: scheduled_name
+                                                ? `scheduled.${scheduled_name}`
+                                                : undefined,
+                                            offset_id: undefined,
+                                        },
                                     })
                                 }}
                                 placeholder={t("scheduled_name", "Scheduled Name")}
@@ -922,22 +952,30 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                         )}
 
                         {/* RuleBuilder - shown after schedule + offset are selected */}
-                        {value.scheduled_name && value.schedule_offset_id && value.event_name && (
-                            <RuleBuilder
-                                rule={value.rule ?? createSimpleEventRule(value.event_name)}
-                                setRule={(rule) =>
-                                    onChange({
-                                        ...value,
-                                        rule: {
-                                            ...rule,
-                                            value: value.event_name,
-                                        },
-                                    })
-                                }
-                                eventName={value.event_name}
-                                headerPrefix={t("entrance_matching")}
-                            />
-                        )}
+                        {value.scheduled_name &&
+                            value.scheduled?.offset_id &&
+                            value.scheduled?.name && (
+                                <RuleBuilder
+                                    rule={
+                                        value.scheduled.rule ??
+                                        createSimpleEventRule(value.scheduled.name)
+                                    }
+                                    setRule={(rule) =>
+                                        onChange({
+                                            ...value,
+                                            scheduled: {
+                                                ...value.scheduled,
+                                                rule: {
+                                                    ...rule,
+                                                    value: value.scheduled?.name,
+                                                },
+                                            },
+                                        })
+                                    }
+                                    eventName={value.scheduled.name}
+                                    headerPrefix={t("entrance_matching")}
+                                />
+                            )}
 
                         {/* Multiple entries toggle */}
                         <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
@@ -990,12 +1028,12 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                             </Label>
                             <ListSelector
                                 projectId={projectId as UUID}
-                                value={value.list_id}
+                                value={value.list?.id}
                                 displayName={value.list_name}
                                 onChange={(list) =>
                                     onChange({
                                         ...value,
-                                        list_id: list.id,
+                                        list: { ...value.list, id: list.id },
                                         list_name: list.name,
                                     })
                                 }
@@ -1007,16 +1045,19 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                                 {t("entrance_list_when", "Enter the journey when")}
                             </Label>
                             <Select
-                                value={value.list_direction ?? "joins"}
+                                value={value.list?.direction ?? "joins"}
                                 onValueChange={(v) => {
                                     const direction = v as ListDirection
                                     onChange({
                                         ...value,
-                                        list_direction: direction,
-                                        exit_on_leave:
-                                            direction === "joins"
-                                                ? (value.exit_on_leave ?? true)
-                                                : false,
+                                        list: {
+                                            ...value.list,
+                                            direction,
+                                            exit_on_leave:
+                                                direction === "joins"
+                                                    ? (value.list?.exit_on_leave ?? true)
+                                                    : false,
+                                        },
                                     })
                                 }}
                             >
@@ -1034,7 +1075,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                             </Select>
                         </div>
 
-                        {(value.list_direction ?? "joins") === "joins" && (
+                        {(value.list?.direction ?? "joins") === "joins" && (
                             <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
                                 <div className="space-y-0.5">
                                     <Label htmlFor="exit-on-leave" className="text-sm font-medium">
@@ -1052,9 +1093,12 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                                 </div>
                                 <Switch
                                     id="exit-on-leave"
-                                    checked={value.exit_on_leave ?? true}
+                                    checked={value.list?.exit_on_leave ?? true}
                                     onCheckedChange={(exit_on_leave) =>
-                                        onChange({ ...value, exit_on_leave })
+                                        onChange({
+                                            ...value,
+                                            list: { ...value.list, exit_on_leave },
+                                        })
                                     }
                                 />
                             </div>
@@ -1113,15 +1157,15 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
             </>
         )
     },
-    validate: ({ trigger, event_name, scheduled_name, schedule_offset_id, list_id }) => {
+    validate: ({ trigger, event, scheduled, list }) => {
         if (trigger === "event") {
-            return !!event_name
+            return !!event?.name
         }
         if (trigger === "scheduled") {
-            return !!scheduled_name && !!schedule_offset_id
+            return !!scheduled?.name && !!scheduled?.offset_id
         }
         if (trigger === "list") {
-            return !!list_id
+            return !!list?.id
         }
         return true
     },

--- a/console/src/views/journey/steps/Entrance.tsx
+++ b/console/src/views/journey/steps/Entrance.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import type {
     JourneyStepType,
+    List,
     Rule,
     RulePath,
     ScheduledSchema,
@@ -32,7 +33,16 @@ import {
     Loader2,
     Plus,
     ArrowLeft,
+    ListChecks,
+    LogOut,
 } from "lucide-react"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
 import { ScheduleOffsetCombobox } from "@/components/schedule-offset-combobox"
 import { formatOffset } from "@/utils"
 import { cn } from "@/utils"
@@ -42,8 +52,10 @@ import { Input } from "@/components/ui/input"
 import { Link } from "react-router"
 import type { UUID } from "@/types/common"
 
+type ListDirection = "joins" | "leaves"
+
 interface EntranceConfig {
-    trigger: "none" | "event" | "scheduled"
+    trigger: "none" | "event" | "scheduled" | "list"
 
     // event based
     event_name?: string
@@ -57,10 +69,16 @@ interface EntranceConfig {
     schedule_offset?: string
     schedule_offset_direction?: string
 
+    // list based
+    list_id?: UUID
+    list_name?: string
+    list_direction?: ListDirection
+    exit_on_leave?: boolean
+
     references?: Array<{ id: UUID; name: string }>
 }
 
-const triggers = ["none", "event", "scheduled"] as const
+const triggers = ["none", "event", "scheduled", "list"] as const
 
 type EventOption = Pick<RulePath, "name" | "path">
 type EventComboboxView = "list" | "create"
@@ -69,6 +87,7 @@ const triggerConfig = {
     none: { icon: Webhook, label: "API" },
     event: { icon: Zap, label: "Event" },
     scheduled: { icon: CalendarClock, label: "Scheduled" },
+    list: { icon: ListChecks, label: "List" },
 } as const
 
 const codeExample = (journeyId: UUID, entranceId: UUID) => `curl --request POST \\
@@ -429,6 +448,119 @@ function EventNameCombobox({ value, onChange, onSearch }: EventNameComboboxProps
     )
 }
 
+interface ListSelectorProps {
+    projectId: UUID
+    value?: UUID
+    displayName?: string
+    onChange: (list: { id: UUID; name: string }) => void
+}
+
+function ListSelector({ projectId, value, displayName, onChange }: ListSelectorProps) {
+    const { t } = useTranslation()
+    const [open, setOpen] = useState(false)
+    const [search, setSearch] = useState("")
+    const [results, setResults] = useState<List[]>([])
+    const [loading, setLoading] = useState(false)
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
+    useEffect(() => {
+        if (!open) return
+        if (debounceRef.current) clearTimeout(debounceRef.current)
+
+        setLoading(true)
+        debounceRef.current = setTimeout(async () => {
+            try {
+                const res = await api.lists.search(projectId, { limit: 50, search })
+                setResults(res.results)
+            } finally {
+                setLoading(false)
+            }
+        }, 250)
+
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current)
+        }
+    }, [open, search, projectId])
+
+    useEffect(() => {
+        if (!open) setSearch("")
+    }, [open])
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={open}
+                    type="button"
+                    className={cn(
+                        "h-9 w-full justify-between shadow-none font-normal",
+                        !value && "text-muted-foreground",
+                    )}
+                >
+                    <span className="flex items-center gap-2 truncate">
+                        <ListChecks className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate text-sm">
+                            {displayName || t("select_list", "Select a list...")}
+                        </span>
+                    </span>
+                    <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent
+                className="w-[var(--radix-popover-trigger-width)] p-0"
+                align="start"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+                <Command shouldFilter={false}>
+                    <CommandInput
+                        placeholder={t("search_lists", "Search lists...")}
+                        value={search}
+                        onValueChange={setSearch}
+                    />
+                    <CommandList>
+                        {loading ? (
+                            <div className="flex items-center justify-center py-6">
+                                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                            </div>
+                        ) : results.length === 0 ? (
+                            <div className="py-6 text-center text-sm text-muted-foreground">
+                                {t("no_lists_found", "No lists found.")}
+                            </div>
+                        ) : (
+                            <div className="max-h-64 overflow-y-auto p-1">
+                                {results.map((list) => (
+                                    <CommandItem
+                                        key={list.id}
+                                        value={list.id}
+                                        onSelect={() => {
+                                            onChange({ id: list.id, name: list.name })
+                                            setOpen(false)
+                                        }}
+                                        className="cursor-pointer"
+                                    >
+                                        <Check
+                                            className={cn(
+                                                "mr-2 h-4 w-4 shrink-0",
+                                                value === list.id ? "opacity-100" : "opacity-0",
+                                            )}
+                                        />
+                                        <span className="truncate text-sm">{list.name}</span>
+                                        <Badge variant="secondary" className="ml-auto shrink-0">
+                                            {list.type}
+                                        </Badge>
+                                    </CommandItem>
+                                ))}
+                            </div>
+                        )}
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    )
+}
+
 export const entranceStep: JourneyStepType<EntranceConfig> = {
     name: "entrance",
     icon: <EntranceStepIcon />,
@@ -446,6 +578,9 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
             schedule_offset_id,
             schedule_offset,
             schedule_offset_direction,
+            list_name,
+            list_direction,
+            exit_on_leave,
             references = [],
         },
     }) {
@@ -494,6 +629,32 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                             </span>
                         )}
                     </span>
+                </div>
+            )
+        }
+
+        if (trigger === "list") {
+            const direction = list_direction ?? "joins"
+            return (
+                <div className="space-y-1.5 max-w-[300px]">
+                    <div className="flex items-center gap-1.5 text-sm">
+                        <ListChecks className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        <span>
+                            {direction === "leaves"
+                                ? t("entrance_list_leaves", "When a user leaves")
+                                : t("entrance_list_joins", "When a user joins")}{" "}
+                            <strong>{list_name || <>&#8211;</>}</strong>
+                        </span>
+                    </div>
+                    {direction === "joins" && exit_on_leave && (
+                        <div className="flex items-center gap-1.5 border-l-2 border-muted pl-2 text-xs text-muted-foreground">
+                            <LogOut className="h-3 w-3 shrink-0" />
+                            {t(
+                                "entrance_list_exit_on_leave_summary",
+                                "Exit when they leave the list",
+                            )}
+                        </div>
+                    )}
                 </div>
             )
         }
@@ -560,6 +721,18 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                 })
             }
         }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+        // Seed sensible defaults for the list trigger: enter on join, and exit
+        // the journey when the user leaves the list.
+        useEffect(() => {
+            if (value.trigger === "list" && value.list_direction === undefined) {
+                onChange({
+                    ...value,
+                    list_direction: "joins",
+                    exit_on_leave: value.exit_on_leave ?? true,
+                })
+            }
+        }, [value.trigger, value.list_direction]) // eslint-disable-line react-hooks/exhaustive-deps
 
         const handleSearch = useCallback(
             async (query: string): Promise<RulePath[]> => {
@@ -808,6 +981,124 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                         )}
                     </>
                 )}
+                {value.trigger === "list" && (
+                    <>
+                        <div className="space-y-1.5">
+                            <Label className="inline-flex items-center gap-0.5 text-sm font-medium">
+                                {t("list", "List")}
+                                <span className="text-destructive">*</span>
+                            </Label>
+                            <ListSelector
+                                projectId={projectId as UUID}
+                                value={value.list_id}
+                                displayName={value.list_name}
+                                onChange={(list) =>
+                                    onChange({
+                                        ...value,
+                                        list_id: list.id,
+                                        list_name: list.name,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div className="space-y-1.5">
+                            <Label className="text-sm font-medium">
+                                {t("entrance_list_when", "Enter the journey when")}
+                            </Label>
+                            <Select
+                                value={value.list_direction ?? "joins"}
+                                onValueChange={(v) => {
+                                    const direction = v as ListDirection
+                                    onChange({
+                                        ...value,
+                                        list_direction: direction,
+                                        exit_on_leave:
+                                            direction === "joins"
+                                                ? (value.exit_on_leave ?? true)
+                                                : false,
+                                    })
+                                }}
+                            >
+                                <SelectTrigger className="h-9">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="joins">
+                                        {t("entrance_list_option_joins", "A user joins the list")}
+                                    </SelectItem>
+                                    <SelectItem value="leaves">
+                                        {t("entrance_list_option_leaves", "A user leaves the list")}
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {(value.list_direction ?? "joins") === "joins" && (
+                            <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+                                <div className="space-y-0.5">
+                                    <Label htmlFor="exit-on-leave" className="text-sm font-medium">
+                                        {t(
+                                            "entrance_list_exit_on_leave",
+                                            "Exit when they leave the list",
+                                        )}
+                                    </Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        {t(
+                                            "entrance_list_exit_on_leave_desc",
+                                            "Automatically remove users from this journey when they leave the list.",
+                                        )}
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="exit-on-leave"
+                                    checked={value.exit_on_leave ?? true}
+                                    onCheckedChange={(exit_on_leave) =>
+                                        onChange({ ...value, exit_on_leave })
+                                    }
+                                />
+                            </div>
+                        )}
+
+                        <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+                            <div className="space-y-0.5">
+                                <Label htmlFor="multiple-list" className="text-sm font-medium">
+                                    {t("entrance_multiple_entries")}
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                    {t("entrance_multiple_entries_desc")}
+                                </p>
+                            </div>
+                            <Switch
+                                id="multiple-list"
+                                checked={Boolean(value.multiple)}
+                                onCheckedChange={(multiple) => onChange({ ...value, multiple })}
+                            />
+                        </div>
+                        {value.multiple && (
+                            <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+                                <div className="space-y-0.5">
+                                    <Label
+                                        htmlFor="concurrent-list"
+                                        className="text-sm font-medium"
+                                    >
+                                        {t("entrance_simultaneous_entries")}
+                                    </Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        {t("entrance_simultaneous_entries_desc")}
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="concurrent-list"
+                                    checked={Boolean(value.concurrent)}
+                                    onCheckedChange={(concurrent) =>
+                                        onChange({ ...value, concurrent })
+                                    }
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
                 {value.trigger === "none" &&
                     (stepId ? (
                         <ApiTriggerSection journeyId={journeyId} stepId={stepId} />
@@ -822,12 +1113,15 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
             </>
         )
     },
-    validate: ({ trigger, event_name, scheduled_name, schedule_offset_id }) => {
+    validate: ({ trigger, event_name, scheduled_name, schedule_offset_id, list_id }) => {
         if (trigger === "event") {
             return !!event_name
         }
         if (trigger === "scheduled") {
             return !!scheduled_name && !!schedule_offset_id
+        }
+        if (trigger === "list") {
+            return !!list_id
         }
         return true
     },

--- a/internal/http/controllers/v1/management/journeys.go
+++ b/internal/http/controllers/v1/management/journeys.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	stdjson "encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -1043,6 +1044,19 @@ func (srv *JourneysController) PublishJourney(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	draftSteps, err := srv.jrny.GetJourneyVersionSteps(ctx, draftVersion.ID)
+	if err != nil {
+		logger.Error("failed to get draft steps", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
+	if err := validateEntranceSteps(draftSteps.OAPI()); err != nil {
+		logger.Info("journey failed entrance validation", zap.Error(err))
+		oapi.WriteProblem(w, err)
+		return
+	}
+
 	tx, err := srv.journeyDB.BeginTxx(ctx, nil)
 	if err != nil {
 		logger.Error("failed to begin transaction", zap.Error(err))
@@ -1096,9 +1110,9 @@ type entranceEventDeps struct {
 
 // listTriggerEvents resolves the enter/exit list membership events for a list
 // trigger entrance from its direction and exit-on-leave setting.
-func listTriggerEvents(data oapi.EntranceStepData) entranceEventDeps {
+func listTriggerEvents(list *oapi.ListTrigger) entranceEventDeps {
 	enter := schemas.EventListUserAdded
-	if data.ListDirection != nil && *data.ListDirection == "leaves" {
+	if list.Direction == oapi.ListLeaves {
 		enter = schemas.EventListUserRemoved
 	}
 
@@ -1106,14 +1120,17 @@ func listTriggerEvents(data oapi.EntranceStepData) entranceEventDeps {
 
 	// Exiting the journey when the user leaves the list only makes sense when
 	// they entered by joining it; the opposite event closes the run.
-	if enter == schemas.EventListUserAdded && data.ExitOnLeave != nil && *data.ExitOnLeave {
+	if enter == schemas.EventListUserAdded && list.ExitOnLeave {
 		deps.Exit = schemas.EventListUserRemoved
 	}
 
 	return deps
 }
 
-// journeyEntranceEventDependencies extracts event dependencies from entrance steps
+// journeyEntranceEventDependencies extracts event dependencies from entrance
+// steps. It is lenient: incompletely configured entrances are skipped rather
+// than rejected so drafts can be saved while they are still being built. The
+// union shape is enforced strictly at publish time (see validateEntranceSteps).
 func journeyEntranceEventDependencies(steps oapi.JourneyStepMap) (map[string]entranceEventDeps, error) {
 	events := make(map[string]entranceEventDeps)
 	for id, step := range steps {
@@ -1127,21 +1144,44 @@ func journeyEntranceEventDependencies(steps oapi.JourneyStepMap) (map[string]ent
 			return nil, err
 		}
 
-		if data.Trigger == nil {
-			continue
-		}
-
-		switch *data.Trigger {
-		case "event", "scheduled":
-			if data.EventName != nil {
-				events[id] = entranceEventDeps{Enter: *data.EventName}
+		switch data.Trigger {
+		case oapi.TriggerEvent:
+			if data.Event != nil && data.Event.Name != "" {
+				events[id] = entranceEventDeps{Enter: data.Event.Name}
 			}
-		case "list":
-			if data.ListID != nil {
-				events[id] = listTriggerEvents(data)
+		case oapi.TriggerScheduled:
+			if data.Scheduled != nil && data.Scheduled.Name != "" {
+				events[id] = entranceEventDeps{Enter: data.Scheduled.Name}
+			}
+		case oapi.TriggerList:
+			if data.List != nil && data.List.ID != uuid.Nil {
+				events[id] = listTriggerEvents(data.List)
 			}
 		}
 	}
 
 	return events, nil
+}
+
+// validateEntranceSteps enforces the entrance trigger union on every entrance
+// step, returning a bad-request problem describing the first violation. It is
+// applied when a journey is published, gating incomplete or malformed
+// entrances that the lenient draft-save path lets through.
+func validateEntranceSteps(steps oapi.JourneyStepMap) error {
+	for id, step := range steps {
+		if step.Type != oapi.JourneyStepTypeEntrance {
+			continue
+		}
+
+		var data oapi.EntranceStepData
+		if err := json.Unmarshal(step.Data, &data); err != nil {
+			return problem.ErrBadRequest(problem.Describe(fmt.Sprintf("entrance %q: %v", id, err)))
+		}
+
+		if err := data.Validate(); err != nil {
+			return problem.ErrBadRequest(problem.Describe(fmt.Sprintf("entrance %q: %v", id, err)))
+		}
+	}
+
+	return nil
 }

--- a/internal/http/controllers/v1/management/journeys.go
+++ b/internal/http/controllers/v1/management/journeys.go
@@ -796,15 +796,28 @@ func (srv *JourneysController) SetJourneySteps(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	for externalID, eventName := range eventDependencies {
-		eventID, err := events.UpsertEvent(ctx, projectID, eventName, subjects.SubjectTypeUser)
+	for externalID, dep := range eventDependencies {
+		var deps []journey.StepEventDependency
+
+		enterID, err := events.UpsertEvent(ctx, projectID, dep.Enter, subjects.SubjectTypeUser)
 		if err != nil {
-			logger.Error("failed to upsert event", zap.String("event", eventName), zap.Error(err))
+			logger.Error("failed to upsert event", zap.String("event", dep.Enter), zap.Error(err))
 			oapi.WriteProblem(w, err)
 			return
 		}
+		deps = append(deps, journey.StepEventDependency{EventID: enterID, Kind: journey.StepEventKindEnter})
 
-		err = journeys.SetJourneyStepEventDependencies(ctx, versionID, externalID, []uuid.UUID{eventID})
+		if dep.Exit != "" {
+			exitID, err := events.UpsertEvent(ctx, projectID, dep.Exit, subjects.SubjectTypeUser)
+			if err != nil {
+				logger.Error("failed to upsert exit event", zap.String("event", dep.Exit), zap.Error(err))
+				oapi.WriteProblem(w, err)
+				return
+			}
+			deps = append(deps, journey.StepEventDependency{EventID: exitID, Kind: journey.StepEventKindExit})
+		}
+
+		err = journeys.SetJourneyStepEventDependencies(ctx, versionID, externalID, deps)
 		if err != nil {
 			logger.Error("failed to set journey step event dependencies", zap.Error(err))
 			oapi.WriteProblem(w, err)
@@ -1073,9 +1086,36 @@ func (srv *JourneysController) PublishJourney(w http.ResponseWriter, r *http.Req
 	json.Write(w, http.StatusOK, updated.OAPI(versionInfo))
 }
 
+// entranceEventDeps describes the events an entrance step depends on. Enter is
+// the event that enrolls a user; Exit (optional) is the event that exits a user
+// from the journey, used by list triggers configured to exit on list leave.
+type entranceEventDeps struct {
+	Enter string
+	Exit  string
+}
+
+// listTriggerEvents resolves the enter/exit list membership events for a list
+// trigger entrance from its direction and exit-on-leave setting.
+func listTriggerEvents(data oapi.EntranceStepData) entranceEventDeps {
+	enter := schemas.EventListUserAdded
+	if data.ListDirection != nil && *data.ListDirection == "leaves" {
+		enter = schemas.EventListUserRemoved
+	}
+
+	deps := entranceEventDeps{Enter: enter}
+
+	// Exiting the journey when the user leaves the list only makes sense when
+	// they entered by joining it; the opposite event closes the run.
+	if enter == schemas.EventListUserAdded && data.ExitOnLeave != nil && *data.ExitOnLeave {
+		deps.Exit = schemas.EventListUserRemoved
+	}
+
+	return deps
+}
+
 // journeyEntranceEventDependencies extracts event dependencies from entrance steps
-func journeyEntranceEventDependencies(steps oapi.JourneyStepMap) (map[string]string, error) {
-	events := make(map[string]string)
+func journeyEntranceEventDependencies(steps oapi.JourneyStepMap) (map[string]entranceEventDeps, error) {
+	events := make(map[string]entranceEventDeps)
 	for id, step := range steps {
 		if step.Type != oapi.JourneyStepTypeEntrance {
 			continue
@@ -1087,8 +1127,19 @@ func journeyEntranceEventDependencies(steps oapi.JourneyStepMap) (map[string]str
 			return nil, err
 		}
 
-		if data.Trigger != nil && (*data.Trigger == "event" || *data.Trigger == "scheduled") && data.EventName != nil {
-			events[id] = *data.EventName
+		if data.Trigger == nil {
+			continue
+		}
+
+		switch *data.Trigger {
+		case "event", "scheduled":
+			if data.EventName != nil {
+				events[id] = entranceEventDeps{Enter: *data.EventName}
+			}
+		case "list":
+			if data.ListID != nil {
+				events[id] = listTriggerEvents(data)
+			}
 		}
 	}
 

--- a/internal/http/controllers/v1/management/journeys_list_trigger_test.go
+++ b/internal/http/controllers/v1/management/journeys_list_trigger_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lunogram/platform/internal/http/controllers/v1/management/oapi"
-	"github.com/lunogram/platform/internal/ptr"
 	"github.com/lunogram/platform/internal/pubsub/schemas"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +32,12 @@ func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
 		{
 			name: "join with exit on leave",
 			data: oapi.EntranceStepData{
-				Trigger:       ptr.To("list"),
-				ListID:        &listID,
-				ListDirection: ptr.To("joins"),
-				ExitOnLeave:   ptr.To(true),
+				Trigger: oapi.TriggerList,
+				List: &oapi.ListTrigger{
+					ID:          listID,
+					Direction:   oapi.ListJoins,
+					ExitOnLeave: true,
+				},
 			},
 			wantInMap: true,
 			wantEnter: schemas.EventListUserAdded,
@@ -45,10 +46,12 @@ func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
 		{
 			name: "join without exit on leave",
 			data: oapi.EntranceStepData{
-				Trigger:       ptr.To("list"),
-				ListID:        &listID,
-				ListDirection: ptr.To("joins"),
-				ExitOnLeave:   ptr.To(false),
+				Trigger: oapi.TriggerList,
+				List: &oapi.ListTrigger{
+					ID:          listID,
+					Direction:   oapi.ListJoins,
+					ExitOnLeave: false,
+				},
 			},
 			wantInMap: true,
 			wantEnter: schemas.EventListUserAdded,
@@ -57,10 +60,12 @@ func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
 		{
 			name: "leave direction never exits",
 			data: oapi.EntranceStepData{
-				Trigger:       ptr.To("list"),
-				ListID:        &listID,
-				ListDirection: ptr.To("leaves"),
-				ExitOnLeave:   ptr.To(true),
+				Trigger: oapi.TriggerList,
+				List: &oapi.ListTrigger{
+					ID:          listID,
+					Direction:   oapi.ListLeaves,
+					ExitOnLeave: true,
+				},
 			},
 			wantInMap: true,
 			wantEnter: schemas.EventListUserRemoved,
@@ -69,9 +74,11 @@ func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
 		{
 			name: "default direction is join",
 			data: oapi.EntranceStepData{
-				Trigger:     ptr.To("list"),
-				ListID:      &listID,
-				ExitOnLeave: ptr.To(true),
+				Trigger: oapi.TriggerList,
+				List: &oapi.ListTrigger{
+					ID:          listID,
+					ExitOnLeave: true,
+				},
 			},
 			wantInMap: true,
 			wantEnter: schemas.EventListUserAdded,
@@ -80,16 +87,17 @@ func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
 		{
 			name: "list trigger without a list is ignored",
 			data: oapi.EntranceStepData{
-				Trigger:       ptr.To("list"),
-				ListDirection: ptr.To("joins"),
+				Trigger: oapi.TriggerList,
 			},
 			wantInMap: false,
 		},
 		{
 			name: "event trigger only registers enter",
 			data: oapi.EntranceStepData{
-				Trigger:   ptr.To("event"),
-				EventName: ptr.To("order.created"),
+				Trigger: oapi.TriggerEvent,
+				Event: &oapi.EventTrigger{
+					Name: "order.created",
+				},
 			},
 			wantInMap: true,
 			wantEnter: "order.created",

--- a/internal/http/controllers/v1/management/journeys_list_trigger_test.go
+++ b/internal/http/controllers/v1/management/journeys_list_trigger_test.go
@@ -1,0 +1,118 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/http/controllers/v1/management/oapi"
+	"github.com/lunogram/platform/internal/ptr"
+	"github.com/lunogram/platform/internal/pubsub/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+func entranceStep(t *testing.T, data oapi.EntranceStepData) oapi.JourneyStep {
+	t.Helper()
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	return oapi.JourneyStep{Type: oapi.JourneyStepTypeEntrance, Data: raw}
+}
+
+func TestJourneyEntranceEventDependencies_ListTrigger(t *testing.T) {
+	t.Parallel()
+
+	listID := uuid.New()
+
+	cases := []struct {
+		name      string
+		data      oapi.EntranceStepData
+		wantInMap bool
+		wantEnter string
+		wantExit  string
+	}{
+		{
+			name: "join with exit on leave",
+			data: oapi.EntranceStepData{
+				Trigger:       ptr.To("list"),
+				ListID:        &listID,
+				ListDirection: ptr.To("joins"),
+				ExitOnLeave:   ptr.To(true),
+			},
+			wantInMap: true,
+			wantEnter: schemas.EventListUserAdded,
+			wantExit:  schemas.EventListUserRemoved,
+		},
+		{
+			name: "join without exit on leave",
+			data: oapi.EntranceStepData{
+				Trigger:       ptr.To("list"),
+				ListID:        &listID,
+				ListDirection: ptr.To("joins"),
+				ExitOnLeave:   ptr.To(false),
+			},
+			wantInMap: true,
+			wantEnter: schemas.EventListUserAdded,
+			wantExit:  "",
+		},
+		{
+			name: "leave direction never exits",
+			data: oapi.EntranceStepData{
+				Trigger:       ptr.To("list"),
+				ListID:        &listID,
+				ListDirection: ptr.To("leaves"),
+				ExitOnLeave:   ptr.To(true),
+			},
+			wantInMap: true,
+			wantEnter: schemas.EventListUserRemoved,
+			wantExit:  "",
+		},
+		{
+			name: "default direction is join",
+			data: oapi.EntranceStepData{
+				Trigger:     ptr.To("list"),
+				ListID:      &listID,
+				ExitOnLeave: ptr.To(true),
+			},
+			wantInMap: true,
+			wantEnter: schemas.EventListUserAdded,
+			wantExit:  schemas.EventListUserRemoved,
+		},
+		{
+			name: "list trigger without a list is ignored",
+			data: oapi.EntranceStepData{
+				Trigger:       ptr.To("list"),
+				ListDirection: ptr.To("joins"),
+			},
+			wantInMap: false,
+		},
+		{
+			name: "event trigger only registers enter",
+			data: oapi.EntranceStepData{
+				Trigger:   ptr.To("event"),
+				EventName: ptr.To("order.created"),
+			},
+			wantInMap: true,
+			wantEnter: "order.created",
+			wantExit:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			steps := oapi.JourneyStepMap{"entrance-1": entranceStep(t, tc.data)}
+			deps, err := journeyEntranceEventDependencies(steps)
+			require.NoError(t, err)
+
+			dep, ok := deps["entrance-1"]
+			require.Equal(t, tc.wantInMap, ok)
+			if !tc.wantInMap {
+				return
+			}
+
+			require.Equal(t, tc.wantEnter, dep.Enter)
+			require.Equal(t, tc.wantExit, dep.Exit)
+		})
+	}
+}

--- a/internal/http/controllers/v1/management/lists.go
+++ b/internal/http/controllers/v1/management/lists.go
@@ -600,6 +600,12 @@ func (srv *ListsController) processUserImport(ctx context.Context, logger *zap.L
 	defer tx.Rollback() //nolint:errcheck
 	stores := subjects.NewState(tx, logger)
 
+	// Track users newly added to the list so that, once the transaction
+	// commits, we can publish list.user.added events. This keeps static lists
+	// consistent with dynamic recompute, which is what list-trigger journeys
+	// listen to.
+	var added []subjects.Recomputed
+
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
@@ -622,17 +628,32 @@ func (srv *ListsController) processUserImport(ctx context.Context, logger *zap.L
 			return err
 		}
 
-		err = stores.AddUserToList(ctx, listID, id)
+		inserted, err := stores.AddUserToListReturning(ctx, listID, id)
 		if err != nil {
 			logger.Warn("failed to add user to list", zap.Stringer("user_id", id), zap.Error(err))
 			return err
+		}
+
+		if inserted {
+			added = append(added, subjects.Recomputed{UserID: id, Action: subjects.RecomputeActionInserted})
 		}
 
 		imported++
 	}
 
 	logger.Info("import completed", zap.Int("users_added", imported))
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	// Publish membership events after commit so list-trigger journeys are
+	// enrolled. A failure here does not roll back the import; it is logged and
+	// the membership change is still durable.
+	if err := consumer.PublishListRecomputeEvents(ctx, logger, srv.pub, projectID, listID, added); err != nil {
+		logger.Error("failed to publish list membership events after import", zap.Error(err))
+	}
+
+	return nil
 }
 
 func (srv *ListsController) GetListUsers(w http.ResponseWriter, r *http.Request, projectID uuid.UUID, listID uuid.UUID, params oapi.GetListUsersParams) {

--- a/internal/http/controllers/v1/management/oapi/journeys.go
+++ b/internal/http/controllers/v1/management/oapi/journeys.go
@@ -62,6 +62,14 @@ type EntranceStepData struct {
 	UserRule         *rules.RuleSet `json:"user_rule,omitempty"`
 	Concurrent       *bool          `json:"concurrent,omitempty"`
 	Multiple         *bool          `json:"multiple,omitempty"`
+
+	// List trigger ("list"): the user enters the journey when they join (or
+	// leave) the referenced list. ListDirection is "joins" (default) or
+	// "leaves". When ExitOnLeave is true (only meaningful for the "joins"
+	// direction) the user is exited from the journey when they leave the list.
+	ListID        *uuid.UUID `json:"list_id,omitempty"`
+	ListDirection *string    `json:"list_direction,omitempty"`
+	ExitOnLeave   *bool      `json:"exit_on_leave,omitempty"`
 }
 
 // ExitStepData represents data for exit step - exits user from journey

--- a/internal/http/controllers/v1/management/oapi/journeys.go
+++ b/internal/http/controllers/v1/management/oapi/journeys.go
@@ -53,23 +53,161 @@ const (
 
 type DelayStepDataFormat string
 
-// EntranceStepData represents data for entrance step - entry point into journey
-type EntranceStepData struct {
-	Trigger          *string        `json:"trigger,omitempty"`
-	EventName        *string        `json:"event_name,omitempty"`
-	ScheduleOffsetID *uuid.UUID     `json:"schedule_offset_id,omitempty"`
-	Rule             *rules.RuleSet `json:"rule,omitempty"`
-	UserRule         *rules.RuleSet `json:"user_rule,omitempty"`
-	Concurrent       *bool          `json:"concurrent,omitempty"`
-	Multiple         *bool          `json:"multiple,omitempty"`
+// TriggerKind selects which entrance trigger sub-object is active.
+type TriggerKind string
 
-	// List trigger ("list"): the user enters the journey when they join (or
-	// leave) the referenced list. ListDirection is "joins" (default) or
-	// "leaves". When ExitOnLeave is true (only meaningful for the "joins"
-	// direction) the user is exited from the journey when they leave the list.
-	ListID        *uuid.UUID `json:"list_id,omitempty"`
-	ListDirection *string    `json:"list_direction,omitempty"`
-	ExitOnLeave   *bool      `json:"exit_on_leave,omitempty"`
+const (
+	// TriggerManual is an API/manually triggered entrance: the user is entered
+	// out-of-band (e.g. via the trigger endpoint) and no trigger sub-object is
+	// set.
+	TriggerManual    TriggerKind = "none"
+	TriggerEvent     TriggerKind = "event"
+	TriggerScheduled TriggerKind = "scheduled"
+	TriggerList      TriggerKind = "list"
+)
+
+// ListDirection is the membership change that fires a list trigger.
+type ListDirection string
+
+const (
+	ListJoins  ListDirection = "joins"
+	ListLeaves ListDirection = "leaves"
+)
+
+// EntranceStepData is the entry point into a journey.
+//
+// It is a tagged union: Trigger selects the kind and exactly the matching
+// sub-object (Event, Scheduled or List) is populated. Each sub-object carries
+// only the fields meaningful for that kind, so trigger-specific requirements
+// live in the type system rather than in documentation. Concurrent and Multiple
+// apply to every kind. Call Validate to enforce the union invariant.
+type EntranceStepData struct {
+	Trigger TriggerKind `json:"trigger"`
+
+	Event     *EventTrigger     `json:"event,omitempty"`
+	Scheduled *ScheduledTrigger `json:"scheduled,omitempty"`
+	List      *ListTrigger      `json:"list,omitempty"`
+
+	// Concurrent allows a user to be in more than one concurrent run of the
+	// journey; Multiple allows re-entry after a previous run has completed.
+	Concurrent bool `json:"concurrent,omitempty"`
+	Multiple   bool `json:"multiple,omitempty"`
+}
+
+// EventTrigger enters the user when a custom event named Name is received.
+type EventTrigger struct {
+	Name string `json:"name"`
+	// Rule is an optional condition evaluated against the event data; the user
+	// only enters when it matches.
+	Rule *rules.RuleSet `json:"rule,omitempty"`
+	// UserRule filters which organization members are enrolled when the event
+	// is organization-level.
+	UserRule *rules.RuleSet `json:"user_rule,omitempty"`
+}
+
+// ScheduledTrigger enters the user when a schedule offset fires.
+type ScheduledTrigger struct {
+	Name     string         `json:"name"`
+	OffsetID *uuid.UUID     `json:"offset_id,omitempty"`
+	Rule     *rules.RuleSet `json:"rule,omitempty"`
+	UserRule *rules.RuleSet `json:"user_rule,omitempty"`
+}
+
+// ListTrigger enters the user when they join or leave the referenced list.
+type ListTrigger struct {
+	ID uuid.UUID `json:"id"`
+	// Direction is "joins" (default) or "leaves".
+	Direction ListDirection `json:"direction,omitempty"`
+	// ExitOnLeave exits the user from the journey when they leave the list. It
+	// is only meaningful for the "joins" direction.
+	ExitOnLeave bool `json:"exit_on_leave,omitempty"`
+}
+
+// EntranceRule returns the optional entrance condition for the active trigger,
+// evaluated against the triggering event's data. It is nil when the trigger
+// carries none (list triggers are matched in the backend instead).
+func (e EntranceStepData) EntranceRule() *rules.RuleSet {
+	switch e.Trigger {
+	case TriggerEvent:
+		if e.Event != nil {
+			return e.Event.Rule
+		}
+	case TriggerScheduled:
+		if e.Scheduled != nil {
+			return e.Scheduled.Rule
+		}
+	}
+	return nil
+}
+
+// MemberRule returns the optional organization-member filter for the active
+// trigger, applied when enrolling members on an organization-level event.
+func (e EntranceStepData) MemberRule() *rules.RuleSet {
+	switch e.Trigger {
+	case TriggerEvent:
+		if e.Event != nil {
+			return e.Event.UserRule
+		}
+	case TriggerScheduled:
+		if e.Scheduled != nil {
+			return e.Scheduled.UserRule
+		}
+	}
+	return nil
+}
+
+// Validate enforces the entrance union invariant: Trigger must be a known kind
+// and exactly the matching sub-object must be populated with its required
+// fields.
+func (e EntranceStepData) Validate() error {
+	var present []TriggerKind
+	if e.Event != nil {
+		present = append(present, TriggerEvent)
+	}
+	if e.Scheduled != nil {
+		present = append(present, TriggerScheduled)
+	}
+	if e.List != nil {
+		present = append(present, TriggerList)
+	}
+
+	switch e.Trigger {
+	case TriggerManual:
+		// API/manual entrances carry no trigger block.
+		if len(present) != 0 {
+			return fmt.Errorf("entrance: manual trigger must not set a trigger block, got %v", present)
+		}
+		return nil
+	case TriggerEvent, TriggerScheduled, TriggerList:
+	default:
+		return fmt.Errorf("entrance: unknown trigger %q", e.Trigger)
+	}
+
+	if len(present) != 1 || present[0] != e.Trigger {
+		return fmt.Errorf("entrance: trigger %q requires exactly its own data block, got %v", e.Trigger, present)
+	}
+
+	switch e.Trigger {
+	case TriggerEvent:
+		if e.Event.Name == "" {
+			return fmt.Errorf("entrance: event trigger requires event.name")
+		}
+	case TriggerScheduled:
+		if e.Scheduled.Name == "" {
+			return fmt.Errorf("entrance: scheduled trigger requires scheduled.name")
+		}
+	case TriggerList:
+		if e.List.ID == uuid.Nil {
+			return fmt.Errorf("entrance: list trigger requires list.id")
+		}
+		switch e.List.Direction {
+		case "", ListJoins, ListLeaves:
+		default:
+			return fmt.Errorf("entrance: list trigger has invalid direction %q", e.List.Direction)
+		}
+	}
+
+	return nil
 }
 
 // ExitStepData represents data for exit step - exits user from journey

--- a/internal/http/controllers/v1/management/oapi/journeys_test.go
+++ b/internal/http/controllers/v1/management/oapi/journeys_test.go
@@ -1,0 +1,155 @@
+package oapi
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/rules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntranceStepData_Validate(t *testing.T) {
+	t.Parallel()
+
+	listID := uuid.New()
+
+	cases := []struct {
+		name    string
+		data    EntranceStepData
+		wantErr bool
+	}{
+		{
+			name: "valid manual trigger",
+			data: EntranceStepData{Trigger: TriggerManual},
+		},
+		{
+			name: "manual trigger must not carry a block",
+			data: EntranceStepData{
+				Trigger: TriggerManual,
+				Event:   &EventTrigger{Name: "order.created"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid event trigger",
+			data: EntranceStepData{
+				Trigger: TriggerEvent,
+				Event:   &EventTrigger{Name: "order.created"},
+			},
+		},
+		{
+			name: "valid scheduled trigger",
+			data: EntranceStepData{
+				Trigger:   TriggerScheduled,
+				Scheduled: &ScheduledTrigger{Name: "reminder"},
+			},
+		},
+		{
+			name: "valid list trigger with default direction",
+			data: EntranceStepData{
+				Trigger: TriggerList,
+				List:    &ListTrigger{ID: listID},
+			},
+		},
+		{
+			name: "valid list trigger leaves",
+			data: EntranceStepData{
+				Trigger: TriggerList,
+				List:    &ListTrigger{ID: listID, Direction: ListLeaves},
+			},
+		},
+		{
+			name:    "unknown trigger",
+			data:    EntranceStepData{Trigger: "segment"},
+			wantErr: true,
+		},
+		{
+			name:    "empty trigger",
+			data:    EntranceStepData{},
+			wantErr: true,
+		},
+		{
+			name: "trigger without its block",
+			data: EntranceStepData{
+				Trigger: TriggerEvent,
+			},
+			wantErr: true,
+		},
+		{
+			name: "mismatched block",
+			data: EntranceStepData{
+				Trigger: TriggerEvent,
+				List:    &ListTrigger{ID: listID},
+			},
+			wantErr: true,
+		},
+		{
+			name: "two blocks set",
+			data: EntranceStepData{
+				Trigger: TriggerList,
+				List:    &ListTrigger{ID: listID},
+				Event:   &EventTrigger{Name: "order.created"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "event trigger missing event name",
+			data: EntranceStepData{
+				Trigger: TriggerEvent,
+				Event:   &EventTrigger{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "list trigger missing list id",
+			data: EntranceStepData{
+				Trigger: TriggerList,
+				List:    &ListTrigger{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "list trigger invalid direction",
+			data: EntranceStepData{
+				Trigger: TriggerList,
+				List:    &ListTrigger{ID: listID, Direction: "sideways"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.data.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEntranceStepData_RuleAccessors(t *testing.T) {
+	t.Parallel()
+
+	rule := &rules.RuleSet{}
+	member := &rules.RuleSet{}
+
+	event := EntranceStepData{
+		Trigger: TriggerEvent,
+		Event:   &EventTrigger{Name: "x", Rule: rule, UserRule: member},
+	}
+	require.Equal(t, rule, event.EntranceRule())
+	require.Equal(t, member, event.MemberRule())
+
+	// List triggers carry no rule; the backend match is authoritative.
+	list := EntranceStepData{
+		Trigger: TriggerList,
+		List:    &ListTrigger{ID: uuid.New()},
+	}
+	require.Nil(t, list.EntranceRule())
+	require.Nil(t, list.MemberRule())
+}

--- a/internal/http/controllers/v1/management/oapi/overlay.yml
+++ b/internal/http/controllers/v1/management/oapi/overlay.yml
@@ -3,15 +3,29 @@ info:
   title: Add rules.RuleSet Go type annotations for server-side code generation
   version: 1.0.0
 actions:
-  - target: $.components.schemas.EntranceStepData.properties.rule
-    description: Add rules.RuleSet type to entrance step rule
+  - target: $.components.schemas.EntranceEventTrigger.properties.rule
+    description: Add rules.RuleSet type to entrance event trigger rule
     update:
       x-go-type: rules.RuleSet
       x-go-type-import:
         path: github.com/lunogram/platform/internal/rules
 
-  - target: $.components.schemas.EntranceStepData.properties.user_rule
-    description: Add rules.RuleSet type to entrance step user_rule
+  - target: $.components.schemas.EntranceEventTrigger.properties.user_rule
+    description: Add rules.RuleSet type to entrance event trigger user_rule
+    update:
+      x-go-type: rules.RuleSet
+      x-go-type-import:
+        path: github.com/lunogram/platform/internal/rules
+
+  - target: $.components.schemas.EntranceScheduledTrigger.properties.rule
+    description: Add rules.RuleSet type to entrance scheduled trigger rule
+    update:
+      x-go-type: rules.RuleSet
+      x-go-type-import:
+        path: github.com/lunogram/platform/internal/rules
+
+  - target: $.components.schemas.EntranceScheduledTrigger.properties.user_rule
+    description: Add rules.RuleSet type to entrance scheduled trigger user_rule
     update:
       x-go-type: rules.RuleSet
       x-go-type-import:

--- a/internal/http/controllers/v1/management/oapi/resources.yml
+++ b/internal/http/controllers/v1/management/oapi/resources.yml
@@ -6522,33 +6522,98 @@ components:
 
     EntranceStepData:
       type: object
-      description: Data for entrance step - entry point into journey
+      description: >
+        Data for entrance step - entry point into journey. Tagged union:
+        `trigger` selects the kind and the matching sub-object (event, scheduled
+        or list) carries its fields. `concurrent` and `multiple` apply to every
+        kind. `none` is an API/manually triggered entrance with no sub-object.
       additionalProperties: false
+      required:
+        - trigger
       properties:
         trigger:
           type: string
-          enum: [none, event]
-          description: Trigger type for entrance
+          enum: [none, event, scheduled, list]
+          description: Selects which trigger sub-object is active
           example: "event"
-        event_name:
+        concurrent:
+          type: boolean
+          description: Allow concurrent journey runs
+          example: false
+        multiple:
+          type: boolean
+          description: Allow re-entry after a previous run completed
+          example: false
+        event:
+          $ref: "#/components/schemas/EntranceEventTrigger"
+        scheduled:
+          $ref: "#/components/schemas/EntranceScheduledTrigger"
+        list:
+          $ref: "#/components/schemas/EntranceListTrigger"
+
+    EntranceEventTrigger:
+      type: object
+      description: Enters the user when a matching custom event is received
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
           type: string
           description: Event name that triggers entrance
           example: "user_signup"
         rule:
           type: object
-          description: Rule for filtering events
+          description: Optional condition evaluated against the event data
           additionalProperties: true
         user_rule:
           type: object
-          description: Rule for filtering users (used with organization events)
+          description: Optional filter for organization members
           additionalProperties: true
-        multiple:
+
+    EntranceScheduledTrigger:
+      type: object
+      description: Enters the user when a schedule offset fires
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Scheduled event name that triggers entrance
+          example: "scheduled.weekly_digest"
+        offset_id:
+          type: string
+          format: uuid
+          description: Schedule offset that fires the entrance
+        rule:
+          type: object
+          description: Optional condition evaluated against the event data
+          additionalProperties: true
+        user_rule:
+          type: object
+          description: Optional filter for organization members
+          additionalProperties: true
+
+    EntranceListTrigger:
+      type: object
+      description: Enters the user when they join or leave the referenced list
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: List whose membership changes trigger entrance
+        direction:
+          type: string
+          enum: [joins, leaves]
+          description: Membership change that fires the trigger (default joins)
+          example: "joins"
+        exit_on_leave:
           type: boolean
-          description: Allow multiple entries
-          example: false
-        concurrent:
-          type: boolean
-          description: Allow concurrent journey runs
+          description: Exit the user when they leave the list (joins direction only)
           example: false
 
     ExitStepData:

--- a/internal/pubsub/consumer/journeys_list_trigger_test.go
+++ b/internal/pubsub/consumer/journeys_list_trigger_test.go
@@ -1,0 +1,283 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cloudproud/graceful"
+	"github.com/google/uuid"
+	"github.com/lunogram/platform/internal/http/controllers/v1/management/oapi"
+	"github.com/lunogram/platform/internal/pubsub"
+	"github.com/lunogram/platform/internal/pubsub/schemas"
+	"github.com/lunogram/platform/internal/store/journey"
+	"github.com/lunogram/platform/internal/store/subjects"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// seedListTriggerJourney creates a published journey whose entrance is a list
+// trigger configured to enter the user when they join listID and (when
+// exitOnLeave is set) exit them when they leave it. It returns the created
+// journey ID and the enter/exit event IDs registered as its dependencies.
+func seedListTriggerJourney(t *testing.T, ctx context.Context, jrny *journey.State, usrs *subjects.State, projectID, listID uuid.UUID, exitOnLeave bool) (journeyID uuid.UUID) {
+	t.Helper()
+
+	journeyID, err := jrny.CreateJourney(ctx, journey.Journey{
+		ProjectID: projectID,
+		Name:      "List Trigger Journey",
+	})
+	require.NoError(t, err)
+
+	versionID, err := jrny.CreateJourneyVersion(ctx, journeyID, "draft")
+	require.NoError(t, err)
+
+	entranceData, err := json.Marshal(oapi.EntranceStepData{
+		Trigger: oapi.TriggerList,
+		List: &oapi.ListTrigger{
+			ID:          listID,
+			Direction:   oapi.ListJoins,
+			ExitOnLeave: exitOnLeave,
+		},
+	})
+	require.NoError(t, err)
+
+	stepMap := oapi.JourneyStepMap{
+		"entrance-1": {
+			Type: "entrance",
+			Data: entranceData,
+			X:    0,
+			Y:    0,
+			Children: []oapi.JourneyStepChild{
+				{ExternalId: "delay-1"},
+			},
+		},
+		"delay-1": {
+			Type: "delay",
+			X:    100,
+			Y:    100,
+		},
+	}
+
+	_, err = jrny.SetJourneySteps(ctx, versionID, stepMap)
+	require.NoError(t, err)
+
+	// Register the same enter/exit dependencies the publish handler would derive
+	// for a list-join entrance configured to exit on leave.
+	addedID, err := usrs.UpsertEvent(ctx, projectID, schemas.EventListUserAdded, subjects.SubjectTypeUser)
+	require.NoError(t, err)
+	removedID, err := usrs.UpsertEvent(ctx, projectID, schemas.EventListUserRemoved, subjects.SubjectTypeUser)
+	require.NoError(t, err)
+
+	deps := []journey.StepEventDependency{{EventID: addedID, Kind: journey.StepEventKindEnter}}
+	if exitOnLeave {
+		deps = append(deps, journey.StepEventDependency{EventID: removedID, Kind: journey.StepEventKindExit})
+	}
+	err = jrny.SetJourneyStepEventDependencies(ctx, versionID, "entrance-1", deps)
+	require.NoError(t, err)
+
+	err = jrny.PublishVersion(ctx, journeyID, versionID)
+	require.NoError(t, err)
+
+	return journeyID
+}
+
+// drainEntrances fetches up to a few journey-entrance messages with a short
+// wait and returns them. An empty slice means nothing was published.
+func drainEntrances(t *testing.T, ctx context.Context, jet jetstream.JetStream, ns Namespace) []schemas.JourneyEntrance {
+	t.Helper()
+
+	consumer, err := jet.Consumer(ctx, ns.Stream(StreamJourneys), ns.Consumer(ConsumerJourneysEntrance))
+	require.NoError(t, err)
+
+	var entrances []schemas.JourneyEntrance
+	for {
+		msgs, err := consumer.Fetch(10, jetstream.FetchMaxWait(2*time.Second))
+		require.NoError(t, err)
+
+		var got int
+		for msg := range msgs.Messages() {
+			got++
+			var entrance schemas.JourneyEntrance
+			require.NoError(t, json.Unmarshal(msg.Data(), &entrance))
+			entrances = append(entrances, entrance)
+			require.NoError(t, msg.Ack())
+		}
+		require.NoError(t, msgs.Error())
+
+		if got == 0 {
+			break
+		}
+	}
+
+	return entrances
+}
+
+// TestPublishUserEventJourneyDependenciesListIDFilter is the headline safety
+// check: a list membership event must only enrol journeys configured for that
+// exact list. A list.user.added for list A must NOT enrol a journey wired to
+// list B.
+func TestPublishUserEventJourneyDependenciesListIDFilter(t *testing.T) {
+	t.Parallel()
+
+	_, usrsDB, jrnyDB, projectID, jet := setupUserEventsTest(t)
+	logger := zaptest.NewLogger(t)
+	ctx := graceful.NewContext(t.Context())
+	ns := testNamespace(t)
+
+	require.NoError(t, Bootstrap(ctx, logger, jet, ns))
+
+	usrs := subjects.NewState(usrsDB, zap.NewNop())
+	jrny := journey.NewState(jrnyDB)
+	pub := pubsub.NewPublisher(jet, string(ns))
+
+	listA := uuid.New()
+	listB := uuid.New()
+	userID := uuid.New()
+
+	// One journey is wired to list B only.
+	journeyB := seedListTriggerJourney(t, ctx, jrny, usrs, projectID, listB, false)
+
+	addedID, err := usrs.UpsertEvent(ctx, projectID, schemas.EventListUserAdded, subjects.SubjectTypeUser)
+	require.NoError(t, err)
+
+	t.Run("cross-list event does not enrol", func(t *testing.T) {
+		event := schemas.UserEvent{
+			ID:        addedID,
+			Name:      schemas.EventListUserAdded,
+			ProjectID: projectID,
+			UserID:    userID,
+			Data:      map[string]any{"list_id": listA.String()},
+		}
+
+		err := PublishUserEventJourneyDependencies(ctx, logger, jrny, pub, event)()
+		require.NoError(t, err)
+
+		entrances := drainEntrances(t, ctx, jet, ns)
+		assert.Empty(t, entrances, "a list.user.added for list A must not enrol a journey configured for list B")
+	})
+
+	t.Run("matching-list event enrols", func(t *testing.T) {
+		event := schemas.UserEvent{
+			ID:        addedID,
+			Name:      schemas.EventListUserAdded,
+			ProjectID: projectID,
+			UserID:    userID,
+			Data:      map[string]any{"list_id": listB.String()},
+		}
+
+		err := PublishUserEventJourneyDependencies(ctx, logger, jrny, pub, event)()
+		require.NoError(t, err)
+
+		entrances := drainEntrances(t, ctx, jet, ns)
+		require.Len(t, entrances, 1, "the journey configured for list B should be enrolled")
+		assert.Equal(t, journeyB, entrances[0].JourneyID)
+		assert.Equal(t, userID, entrances[0].UserID)
+		assert.Equal(t, "entrance-1", entrances[0].ExternalStepID)
+	})
+
+	t.Run("missing list_id does not enrol", func(t *testing.T) {
+		event := schemas.UserEvent{
+			ID:        addedID,
+			Name:      schemas.EventListUserAdded,
+			ProjectID: projectID,
+			UserID:    userID,
+			Data:      map[string]any{},
+		}
+
+		err := PublishUserEventJourneyDependencies(ctx, logger, jrny, pub, event)()
+		require.NoError(t, err)
+
+		entrances := drainEntrances(t, ctx, jet, ns)
+		assert.Empty(t, entrances, "an event without a list_id must not enrol a list-trigger journey")
+	})
+}
+
+// TestCompleteUserEventJourneyExits covers the runtime exit path: a
+// list.user.removed event completes the user's active runs for a journey
+// configured to exit on leaving that list, and a mismatched list_id is skipped.
+func TestCompleteUserEventJourneyExits(t *testing.T) {
+	t.Parallel()
+
+	_, usrsDB, jrnyDB, projectID, jet := setupUserEventsTest(t)
+	logger := zaptest.NewLogger(t)
+	ctx := graceful.NewContext(t.Context())
+	ns := testNamespace(t)
+
+	require.NoError(t, Bootstrap(ctx, logger, jet, ns))
+
+	usrs := subjects.NewState(usrsDB, zap.NewNop())
+	jrny := journey.NewState(jrnyDB)
+
+	listID := uuid.New()
+	otherListID := uuid.New()
+	userID := uuid.New()
+
+	journeyID := seedListTriggerJourney(t, ctx, jrny, usrs, projectID, listID, true)
+
+	// Put the user into an active run started from the list-join entrance.
+	entryID := uuid.New()
+	_, err := jrny.CreateUserJourneyState(ctx, journey.JourneyUserState{
+		JourneyID:      journeyID,
+		JourneyEntryID: entryID,
+		UserID:         userID,
+		ExternalStepID: "entrance-1",
+	})
+	require.NoError(t, err)
+
+	resumeAt := time.Now().Add(time.Hour)
+	_, err = jrny.CreateUserJourneyState(ctx, journey.JourneyUserState{
+		JourneyID:      journeyID,
+		JourneyEntryID: entryID,
+		UserID:         userID,
+		ExternalStepID: "delay-1",
+		ResumeAt:       &resumeAt,
+	})
+	require.NoError(t, err)
+
+	removedID, err := usrs.UpsertEvent(ctx, projectID, schemas.EventListUserRemoved, subjects.SubjectTypeUser)
+	require.NoError(t, err)
+
+	t.Run("mismatched list_id is skipped", func(t *testing.T) {
+		event := schemas.UserEvent{
+			ID:        removedID,
+			Name:      schemas.EventListUserRemoved,
+			ProjectID: projectID,
+			UserID:    userID,
+			Data:      map[string]any{"list_id": otherListID.String()},
+		}
+
+		err := CompleteUserEventJourneyExits(ctx, logger, jrny, event)()
+		require.NoError(t, err)
+
+		state, err := jrny.GetUserJourneyState(ctx, entryID, "entrance-1")
+		require.NoError(t, err)
+		assert.Nil(t, state.CompletedAt, "leaving a different list must not complete the run")
+	})
+
+	t.Run("matching list leave completes the run", func(t *testing.T) {
+		event := schemas.UserEvent{
+			ID:        removedID,
+			Name:      schemas.EventListUserRemoved,
+			ProjectID: projectID,
+			UserID:    userID,
+			Data:      map[string]any{"list_id": listID.String()},
+		}
+
+		err := CompleteUserEventJourneyExits(ctx, logger, jrny, event)()
+		require.NoError(t, err)
+
+		entrance, err := jrny.GetUserJourneyState(ctx, entryID, "entrance-1")
+		require.NoError(t, err)
+		require.NotNil(t, entrance.CompletedAt, "leaving the configured list completes the entrance state")
+
+		delay, err := jrny.GetUserJourneyState(ctx, entryID, "delay-1")
+		require.NoError(t, err)
+		require.NotNil(t, delay.CompletedAt, "the in-flight step in the same run is completed too")
+		assert.Nil(t, delay.ResumeAt)
+	})
+}

--- a/internal/pubsub/consumer/match_organization_events.go
+++ b/internal/pubsub/consumer/match_organization_events.go
@@ -127,8 +127,8 @@ func PublishMatchedOrgEntrances(ctx context.Context, logger *zap.Logger, usrs *s
 				}
 			}
 
-			if entrance.Rule != nil {
-				match, err := evaluator.Evaluate(*entrance.Rule, event.Data)
+			if rule := entrance.EntranceRule(); rule != nil {
+				match, err := evaluator.Evaluate(*rule, event.Data)
 				if err != nil {
 					logger.Error("failed to evaluate journey entrance rule", zap.Error(err))
 					return err
@@ -145,8 +145,8 @@ func PublishMatchedOrgEntrances(ctx context.Context, logger *zap.Logger, usrs *s
 				return err
 			}
 
-			multiple := entrance.Multiple != nil && *entrance.Multiple
-			concurrent := entrance.Concurrent != nil && *entrance.Concurrent
+			multiple := entrance.Multiple
+			concurrent := entrance.Concurrent
 
 			for _, orgID := range orgIDs {
 				logger.Info("publishing journey entrances for organization members",
@@ -177,7 +177,7 @@ func PublishMatchedOrgEntrances(ctx context.Context, logger *zap.Logger, usrs *s
 					return nil
 				}
 
-				_, err = usrs.ScanOrganizationMembers(ctx, event.ProjectID, orgID, entrance.UserRule, scanner)
+				_, err = usrs.ScanOrganizationMembers(ctx, event.ProjectID, orgID, entrance.MemberRule(), scanner)
 				if err != nil {
 					logger.Error("failed to scan organization members", zap.Error(err), zap.Stringer("organization_id", orgID))
 					return err

--- a/internal/pubsub/consumer/match_user_events.go
+++ b/internal/pubsub/consumer/match_user_events.go
@@ -124,12 +124,12 @@ func PublishMatchedUserEntrances(ctx context.Context, logger *zap.Logger, jrny *
 				}
 			}
 
-			if entrance.Rule != nil {
+			if rule := entrance.EntranceRule(); rule != nil {
 				data := map[string]any{
 					"data": event.Data,
 				}
 
-				match, err := evaluator.Evaluate(*entrance.Rule, data)
+				match, err := evaluator.Evaluate(*rule, data)
 				if err != nil {
 					logger.Error("failed to evaluate journey entrance rule", zap.Error(err))
 					return err
@@ -146,8 +146,8 @@ func PublishMatchedUserEntrances(ctx context.Context, logger *zap.Logger, jrny *
 				return err
 			}
 
-			multiple := entrance.Multiple != nil && *entrance.Multiple
-			concurrent := entrance.Concurrent != nil && *entrance.Concurrent
+			multiple := entrance.Multiple
+			concurrent := entrance.Concurrent
 
 			logger.Info("publishing journey entrances for matched users",
 				zap.Stringer("journey_id", dep.JourneyID),

--- a/internal/pubsub/consumer/organization_events.go
+++ b/internal/pubsub/consumer/organization_events.go
@@ -158,8 +158,8 @@ func PublishOrganizationEventJourneyDependencies(ctx context.Context, logger *za
 			}
 
 			// Evaluate event conditions in-memory
-			if entrance.Rule != nil {
-				match, err := evaluator.Evaluate(*entrance.Rule, event.Data)
+			if rule := entrance.EntranceRule(); rule != nil {
+				match, err := evaluator.Evaluate(*rule, event.Data)
 				if err != nil {
 					logger.Error("failed to evaluate journey entrance rule", zap.Error(err))
 					return err
@@ -181,8 +181,8 @@ func PublishOrganizationEventJourneyDependencies(ctx context.Context, logger *za
 				return err
 			}
 
-			multiple := entrance.Multiple != nil && *entrance.Multiple
-			concurrent := entrance.Concurrent != nil && *entrance.Concurrent
+			multiple := entrance.Multiple
+			concurrent := entrance.Concurrent
 
 			scanner := func(userID uuid.UUID) error {
 				msg := schemas.JourneyEntrance{
@@ -207,7 +207,7 @@ func PublishOrganizationEventJourneyDependencies(ctx context.Context, logger *za
 				return nil
 			}
 
-			_, err = usrs.ScanOrganizationMembers(ctx, event.ProjectID, event.OrganizationID, entrance.UserRule, scanner)
+			_, err = usrs.ScanOrganizationMembers(ctx, event.ProjectID, event.OrganizationID, entrance.MemberRule(), scanner)
 			if err != nil {
 				logger.Error("failed to scan organization members", zap.Error(err))
 				return err

--- a/internal/pubsub/consumer/user_events.go
+++ b/internal/pubsub/consumer/user_events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -77,6 +78,7 @@ func UserEventsHandler(logger *zap.Logger, usrs *subjects.State, jrny *journey.S
 		wg.Go(PublishUserEventSchema(ctx, logger, pub, event, schemaCache))
 		wg.Go(PublishUserEventListDependencies(ctx, logger, usrs, pub, event))
 		wg.Go(PublishUserEventJourneyDependencies(ctx, logger, jrny, pub, event))
+		wg.Go(CompleteUserEventJourneyExits(ctx, logger, jrny, event))
 
 		err = wg.Wait()
 		if err != nil {
@@ -163,6 +165,19 @@ func PublishUserEventJourneyDependencies(ctx context.Context, logger *zap.Logger
 				}
 			}
 
+			// List triggers reuse the list membership events but must only
+			// enrol users for their own list. The list match is authoritative
+			// in the backend rather than relying on a generated rule.
+			if entrance.Trigger != nil && *entrance.Trigger == "list" {
+				if entrance.ListID == nil {
+					continue
+				}
+				listID, _ := event.Data["list_id"].(string)
+				if !strings.EqualFold(listID, entrance.ListID.String()) {
+					continue
+				}
+			}
+
 			if entrance.Rule != nil {
 				data := map[string]any{
 					"data": event.Data,
@@ -209,6 +224,57 @@ func PublishUserEventJourneyDependencies(ctx context.Context, logger *zap.Logger
 			}
 
 			metrics.EventsJourneyTriggersTotal.WithLabelValues("user").Inc()
+		}
+
+		return nil
+	}
+}
+
+// CompleteUserEventJourneyExits returns a function that exits the user from any
+// journey whose list-trigger entrance is configured to exit on list leave when
+// the matching list membership event fires. It completes the user's active runs
+// started from that entrance rather than routing through an in-flow exit step.
+func CompleteUserEventJourneyExits(ctx context.Context, logger *zap.Logger, jrny *journey.State, event schemas.UserEvent) func() error {
+	return func() error {
+		deps, err := jrny.ListEventJourneyExitDependencies(ctx, event.ID)
+		if err != nil {
+			logger.Error("failed to list journey exit dependencies", zap.Error(err))
+			return err
+		}
+
+		if len(deps) == 0 {
+			return nil
+		}
+
+		eventListID, _ := event.Data["list_id"].(string)
+		now := time.Now()
+
+		for _, dep := range deps {
+			entrance := oapi.EntranceStepData{}
+			if dep.Data != nil {
+				if err := json.Unmarshal(*dep.Data, &entrance); err != nil {
+					return err
+				}
+			}
+
+			if entrance.ListID == nil || !strings.EqualFold(eventListID, entrance.ListID.String()) {
+				continue
+			}
+
+			affected, err := jrny.CompleteUserJourneyEntryStates(ctx, dep.JourneyID, event.UserID, dep.ExternalID, now)
+			if err != nil {
+				logger.Error("failed to complete journey entry states on list leave", zap.Error(err))
+				return err
+			}
+
+			if affected > 0 {
+				logger.Info("exited user from journey on list leave",
+					zap.Stringer("journey_id", dep.JourneyID),
+					zap.Stringer("user_id", event.UserID),
+					zap.Int64("states_completed", affected),
+				)
+				metrics.JourneyExitsTotal.WithLabelValues(event.ProjectID.String()).Inc()
+			}
 		}
 
 		return nil

--- a/internal/pubsub/consumer/user_events.go
+++ b/internal/pubsub/consumer/user_events.go
@@ -168,22 +168,22 @@ func PublishUserEventJourneyDependencies(ctx context.Context, logger *zap.Logger
 			// List triggers reuse the list membership events but must only
 			// enrol users for their own list. The list match is authoritative
 			// in the backend rather than relying on a generated rule.
-			if entrance.Trigger != nil && *entrance.Trigger == "list" {
-				if entrance.ListID == nil {
+			if entrance.Trigger == oapi.TriggerList {
+				if entrance.List == nil {
 					continue
 				}
 				listID, _ := event.Data["list_id"].(string)
-				if !strings.EqualFold(listID, entrance.ListID.String()) {
+				if !strings.EqualFold(listID, entrance.List.ID.String()) {
 					continue
 				}
 			}
 
-			if entrance.Rule != nil {
+			if rule := entrance.EntranceRule(); rule != nil {
 				data := map[string]any{
 					"data": event.Data,
 				}
 
-				match, err := evaluator.Evaluate(*entrance.Rule, data)
+				match, err := evaluator.Evaluate(*rule, data)
 				if err != nil {
 					logger.Error("failed to evaluate journey entrance rule", zap.Error(err))
 					return err
@@ -211,8 +211,8 @@ func PublishUserEventJourneyDependencies(ctx context.Context, logger *zap.Logger
 				VersionID:      dep.VersionID,
 				UserID:         event.UserID,
 				ExternalStepID: dep.ExternalID,
-				Multiple:       entrance.Multiple != nil && *entrance.Multiple,
-				Concurrent:     entrance.Concurrent != nil && *entrance.Concurrent,
+				Multiple:       entrance.Multiple,
+				Concurrent:     entrance.Concurrent,
 				Data:           event.Data,
 				Children:       childrenJSON,
 			}
@@ -257,7 +257,7 @@ func CompleteUserEventJourneyExits(ctx context.Context, logger *zap.Logger, jrny
 				}
 			}
 
-			if entrance.ListID == nil || !strings.EqualFold(eventListID, entrance.ListID.String()) {
+			if entrance.List == nil || !strings.EqualFold(eventListID, entrance.List.ID.String()) {
 				continue
 			}
 

--- a/internal/store/journey/journeys.go
+++ b/internal/store/journey/journeys.go
@@ -569,8 +569,8 @@ func (s *JourneysStore) CopyVersionSteps(ctx context.Context, fromVersionID, toV
 
 	// Copy event dependencies
 	copyDepsStmt := `
-	INSERT INTO journey_version_step_events (version_id, external_id, event_id)
-	SELECT $1, external_id, event_id
+	INSERT INTO journey_version_step_events (version_id, external_id, event_id, kind)
+	SELECT $1, external_id, event_id, kind
 	FROM journey_version_step_events
 	WHERE version_id = $2`
 
@@ -856,7 +856,23 @@ func (s *JourneysStore) SetJourneyStepChildren(ctx context.Context, versionID uu
 	return nil
 }
 
-func (s *JourneysStore) SetJourneyStepEventDependencies(ctx context.Context, versionID uuid.UUID, externalID string, eventIDs []uuid.UUID) error {
+// StepEventDependency associates an event with the role it plays for an
+// entrance step: KindEnter triggers enrollment, KindExit completes the user's
+// active runs (used by list triggers to exit a user when they leave the list).
+type StepEventDependency struct {
+	EventID uuid.UUID
+	Kind    string
+}
+
+const (
+	StepEventKindEnter = "enter"
+	StepEventKindExit  = "exit"
+)
+
+// SetJourneyStepEventDependencies replaces all event dependencies for the given
+// entrance step with the supplied set. Both enter and exit dependencies are
+// stored in the same table and distinguished by their kind.
+func (s *JourneysStore) SetJourneyStepEventDependencies(ctx context.Context, versionID uuid.UUID, externalID string, deps []StepEventDependency) error {
 	deleteStmt := `
 	DELETE FROM journey_version_step_events
 	WHERE version_id = $1 AND external_id = $2`
@@ -866,16 +882,21 @@ func (s *JourneysStore) SetJourneyStepEventDependencies(ctx context.Context, ver
 		return err
 	}
 
-	if len(eventIDs) == 0 {
+	if len(deps) == 0 {
 		return nil
 	}
 
 	stmt := `
-	INSERT INTO journey_version_step_events (version_id, external_id, event_id)
-	VALUES ($1, $2, $3)`
+	INSERT INTO journey_version_step_events (version_id, external_id, event_id, kind)
+	VALUES ($1, $2, $3, $4)
+	ON CONFLICT DO NOTHING`
 
-	for _, eventID := range eventIDs {
-		_, err = s.db.ExecContext(ctx, stmt, versionID, externalID, eventID)
+	for _, dep := range deps {
+		kind := dep.Kind
+		if kind == "" {
+			kind = StepEventKindEnter
+		}
+		_, err = s.db.ExecContext(ctx, stmt, versionID, externalID, dep.EventID, kind)
 		if err != nil {
 			return err
 		}
@@ -1045,8 +1066,8 @@ func (s *JourneysStore) CopyVersionContent(ctx context.Context, sourceVersionID,
 	}
 
 	copyEvents := `
-	INSERT INTO journey_version_step_events (version_id, external_id, event_id)
-	SELECT $1, external_id, event_id
+	INSERT INTO journey_version_step_events (version_id, external_id, event_id, kind)
+	SELECT $1, external_id, event_id, kind
 	FROM journey_version_step_events
 	WHERE version_id = $2`
 
@@ -1403,6 +1424,31 @@ func (s *JourneysStore) CompleteJourneyEntryStates(ctx context.Context, journeyI
 	return err
 }
 
+// CompleteUserJourneyEntryStates completes the active (non-completed) journey
+// states of a single user for every run that was started from the given
+// entrance step. It is used to exit a user from a journey in response to an
+// external signal, such as the user leaving a list, without going through an
+// in-flow exit step.
+func (s *JourneysStore) CompleteUserJourneyEntryStates(ctx context.Context, journeyID, userID uuid.UUID, entranceExternalID string, completedAt time.Time) (int64, error) {
+	stmt := `
+	UPDATE journey_user_state
+	SET completed_at = $1, resume_at = NULL
+	WHERE journey_id = $2
+	AND user_id = $3
+	AND completed_at IS NULL
+	AND journey_entry_id = ANY(
+		SELECT journey_entry_id FROM journey_user_state
+		WHERE journey_id = $2 AND user_id = $3 AND external_step_id = $4
+	)`
+
+	result, err := s.db.ExecContext(ctx, stmt, completedAt, journeyID, userID, entranceExternalID)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
 func (s *JourneysStore) ListEventJourneyDependencies(ctx context.Context, eventID uuid.UUID) ([]JourneyEntranceStep, error) {
 	query := `
 	SELECT
@@ -1423,9 +1469,39 @@ func (s *JourneysStore) ListEventJourneyDependencies(ctx context.Context, eventI
 	JOIN journey_version_steps jvs ON jvs.version_id = jv.id AND jvs.external_id = jvse.external_id
 	LEFT JOIN journey_version_step_children c ON jvs.version_id = c.version_id AND jvs.external_id = c.parent_external_id
 	WHERE jvse.event_id = $1
+	AND jvse.kind = 'enter'
 	AND j.deleted_at IS NULL
 	AND jvs.type = 'entrance'
 	GROUP BY j.id, jv.id, jvs.id`
+
+	var entrances []JourneyEntranceStep
+	err := s.db.SelectContext(ctx, &entrances, query, eventID)
+	return entrances, err
+}
+
+// ListEventJourneyExitDependencies returns published entrance steps that have
+// registered the given event as an exit dependency (kind = 'exit'). These are
+// list-trigger entrances configured to exit a user from the journey when the
+// opposite list membership event fires. Children are not needed for exits.
+func (s *JourneysStore) ListEventJourneyExitDependencies(ctx context.Context, eventID uuid.UUID) ([]JourneyEntranceStep, error) {
+	query := `
+	SELECT
+		j.id AS journey_id,
+		jv.id AS version_id,
+		jvs.id AS step_id,
+		jvs.external_id,
+		jvs.type,
+		jvs.data_key,
+		jvs.data,
+		'[]'::jsonb AS children
+	FROM journeys j
+	JOIN journey_versions jv ON jv.id = j.version_id AND jv.status = 'published'
+	JOIN journey_version_step_events jvse ON jvse.version_id = jv.id
+	JOIN journey_version_steps jvs ON jvs.version_id = jv.id AND jvs.external_id = jvse.external_id
+	WHERE jvse.event_id = $1
+	AND jvse.kind = 'exit'
+	AND j.deleted_at IS NULL
+	AND jvs.type = 'entrance'`
 
 	var entrances []JourneyEntranceStep
 	err := s.db.SelectContext(ctx, &entrances, query, eventID)

--- a/internal/store/journey/journeys_test.go
+++ b/internal/store/journey/journeys_test.go
@@ -333,6 +333,197 @@ func TestJourneysStoreEventDependencies(t *testing.T) {
 	})
 }
 
+func TestJourneysStoreListExitDependencies(t *testing.T) {
+	t.Parallel()
+
+	store, db := NewContainerStore(t)
+	ctx := context.Background()
+	projectID := uuid.New()
+
+	journeyID, err := store.CreateJourney(ctx, Journey{
+		ProjectID: projectID,
+		Name:      "List Trigger Journey",
+	})
+	require.NoError(t, err)
+
+	versionID, err := store.CreateJourneyVersion(ctx, journeyID, "draft")
+	require.NoError(t, err)
+
+	stepMap := oapi.JourneyStepMap{
+		"entrance-1": {
+			Type: "entrance",
+			Name: ptr.To("List Entrance"),
+			X:    0,
+			Y:    0,
+			Children: []oapi.JourneyStepChild{
+				{ExternalId: "step-2"},
+			},
+		},
+		"step-2": {
+			Type: "exit",
+			X:    100,
+			Y:    100,
+		},
+	}
+
+	_, err = store.SetJourneySteps(ctx, versionID, stepMap)
+	require.NoError(t, err)
+
+	enterEventID := uuid.New()
+	exitEventID := uuid.New()
+
+	// A list-join entrance configured to exit on leave registers both an enter
+	// dependency (list.user.added) and an exit dependency (list.user.removed).
+	err = store.SetJourneyStepEventDependencies(ctx, versionID, "entrance-1", []StepEventDependency{
+		{EventID: enterEventID, Kind: StepEventKindEnter},
+		{EventID: exitEventID, Kind: StepEventKindExit},
+	})
+	require.NoError(t, err)
+
+	t.Run("both kinds are persisted", func(t *testing.T) {
+		var enterCount, exitCount int
+		require.NoError(t, db.GetContext(ctx, &enterCount,
+			`SELECT COUNT(*) FROM journey_version_step_events WHERE version_id = $1 AND kind = 'enter'`, versionID))
+		require.NoError(t, db.GetContext(ctx, &exitCount,
+			`SELECT COUNT(*) FROM journey_version_step_events WHERE version_id = $1 AND kind = 'exit'`, versionID))
+		assert.Equal(t, 1, enterCount)
+		assert.Equal(t, 1, exitCount)
+	})
+
+	t.Run("exit dependencies only surface for published versions", func(t *testing.T) {
+		// Before publishing, the entrance lives on a draft version and must not
+		// be returned: the runtime only acts on published journeys.
+		deps, err := store.ListEventJourneyExitDependencies(ctx, exitEventID)
+		require.NoError(t, err)
+		assert.Empty(t, deps)
+
+		err = store.PublishVersion(ctx, journeyID, versionID)
+		require.NoError(t, err)
+
+		deps, err = store.ListEventJourneyExitDependencies(ctx, exitEventID)
+		require.NoError(t, err)
+		require.Len(t, deps, 1)
+		assert.Equal(t, journeyID, deps[0].JourneyID)
+		assert.Equal(t, "entrance-1", deps[0].ExternalID)
+		assert.Equal(t, "entrance", deps[0].Type)
+	})
+
+	t.Run("the enter event is not returned as an exit dependency", func(t *testing.T) {
+		deps, err := store.ListEventJourneyExitDependencies(ctx, enterEventID)
+		require.NoError(t, err)
+		assert.Empty(t, deps, "enter dependency must not be treated as an exit dependency")
+
+		entrances, err := store.ListEventJourneyDependencies(ctx, enterEventID)
+		require.NoError(t, err)
+		require.Len(t, entrances, 1, "enter event drives enrollment")
+		assert.Equal(t, "entrance-1", entrances[0].ExternalID)
+	})
+}
+
+func TestJourneysStoreCompleteUserJourneyEntryStates(t *testing.T) {
+	t.Parallel()
+
+	store, _ := NewContainerStore(t)
+	ctx := context.Background()
+	projectID := uuid.New()
+
+	journeyID, err := store.CreateJourney(ctx, Journey{
+		ProjectID: projectID,
+		Name:      "Exit On Leave Journey",
+	})
+	require.NoError(t, err)
+
+	versionID, err := store.CreateJourneyVersion(ctx, journeyID, "draft")
+	require.NoError(t, err)
+
+	stepMap := oapi.JourneyStepMap{
+		"entrance-1": {
+			Type: "entrance",
+			X:    0,
+			Y:    0,
+			Children: []oapi.JourneyStepChild{
+				{ExternalId: "delay-1"},
+			},
+		},
+		"delay-1": {
+			Type: "delay",
+			X:    100,
+			Y:    100,
+		},
+	}
+
+	_, err = store.SetJourneySteps(ctx, versionID, stepMap)
+	require.NoError(t, err)
+
+	err = store.PublishVersion(ctx, journeyID, versionID)
+	require.NoError(t, err)
+
+	userID := uuid.New()
+	entryID := uuid.New()
+
+	// The user has an active entrance state plus an in-flight delay state under
+	// the same journey entry. Both belong to the run that started at entrance-1.
+	_, err = store.CreateUserJourneyState(ctx, JourneyUserState{
+		JourneyID:      journeyID,
+		JourneyEntryID: entryID,
+		UserID:         userID,
+		ExternalStepID: "entrance-1",
+	})
+	require.NoError(t, err)
+
+	resumeAt := time.Now().Add(24 * time.Hour)
+	_, err = store.CreateUserJourneyState(ctx, JourneyUserState{
+		JourneyID:      journeyID,
+		JourneyEntryID: entryID,
+		UserID:         userID,
+		ExternalStepID: "delay-1",
+		ResumeAt:       &resumeAt,
+	})
+	require.NoError(t, err)
+
+	t.Run("completes every active state of the matching run", func(t *testing.T) {
+		now := time.Now()
+		affected, err := store.CompleteUserJourneyEntryStates(ctx, journeyID, userID, "entrance-1", now)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), affected, "both the entrance and the in-flight delay should be completed")
+
+		entrance, err := store.GetUserJourneyState(ctx, entryID, "entrance-1")
+		require.NoError(t, err)
+		require.NotNil(t, entrance.CompletedAt)
+
+		delay, err := store.GetUserJourneyState(ctx, entryID, "delay-1")
+		require.NoError(t, err)
+		require.NotNil(t, delay.CompletedAt)
+		assert.Nil(t, delay.ResumeAt, "resume_at is cleared so the scheduler stops chasing the run")
+	})
+
+	t.Run("is idempotent once the run is completed", func(t *testing.T) {
+		affected, err := store.CompleteUserJourneyEntryStates(ctx, journeyID, userID, "entrance-1", time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), affected, "already-completed states are not touched again")
+	})
+
+	t.Run("leaves other users' runs untouched", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherEntryID := uuid.New()
+		_, err := store.CreateUserJourneyState(ctx, JourneyUserState{
+			JourneyID:      journeyID,
+			JourneyEntryID: otherEntryID,
+			UserID:         otherUserID,
+			ExternalStepID: "entrance-1",
+		})
+		require.NoError(t, err)
+
+		affected, err := store.CompleteUserJourneyEntryStates(ctx, journeyID, userID, "entrance-1", time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), affected, "completing the first user must not reach the second user")
+
+		other, err := store.GetUserJourneyState(ctx, otherEntryID, "entrance-1")
+		require.NoError(t, err)
+		assert.Nil(t, other.CompletedAt, "the other user's run is still active")
+	})
+}
+
 func TestJourneysStoreUserJourneyState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/journey/journeys_test.go
+++ b/internal/store/journey/journeys_test.go
@@ -321,7 +321,7 @@ func TestJourneysStoreEventDependencies(t *testing.T) {
 		_, err := store.SetJourneySteps(ctx, versionID, stepMap)
 		require.NoError(t, err)
 
-		err = store.SetJourneyStepEventDependencies(ctx, versionID, "entrance-1", []uuid.UUID{eventID})
+		err = store.SetJourneyStepEventDependencies(ctx, versionID, "entrance-1", []StepEventDependency{{EventID: eventID, Kind: StepEventKindEnter}})
 		require.NoError(t, err)
 
 		var count int

--- a/internal/store/journey/migrations/1784500000_journey_step_event_kind.down.sql
+++ b/internal/store/journey/migrations/1784500000_journey_step_event_kind.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE journey_version_step_events
+    DROP CONSTRAINT journey_version_step_events_pkey;
+
+DELETE FROM journey_version_step_events WHERE kind <> 'enter';
+
+ALTER TABLE journey_version_step_events
+    DROP COLUMN kind;
+
+ALTER TABLE journey_version_step_events
+    ADD PRIMARY KEY (version_id, external_id, event_id);

--- a/internal/store/journey/migrations/1784500000_journey_step_event_kind.up.sql
+++ b/internal/store/journey/migrations/1784500000_journey_step_event_kind.up.sql
@@ -1,0 +1,15 @@
+-- Distinguish the role an event dependency plays for an entrance step.
+-- 'enter' (the default) means the event triggers enrollment into the journey.
+-- 'exit'  means the event completes the user's active runs from that entrance
+--         (used by list triggers to exit a user when they leave the list).
+ALTER TABLE journey_version_step_events
+    ADD COLUMN kind TEXT NOT NULL DEFAULT 'enter'
+    CONSTRAINT journey_version_step_events_kind_check CHECK (kind IN ('enter', 'exit'));
+
+-- An entrance may now register the same event for both an enter and an exit
+-- role across different entrances, so widen the primary key to include kind.
+ALTER TABLE journey_version_step_events
+    DROP CONSTRAINT journey_version_step_events_pkey;
+
+ALTER TABLE journey_version_step_events
+    ADD PRIMARY KEY (version_id, external_id, event_id, kind);

--- a/internal/store/subjects/lists.go
+++ b/internal/store/subjects/lists.go
@@ -408,13 +408,31 @@ func (s *ListsStore) PublishVersion(ctx context.Context, listID, versionID uuid.
 }
 
 func (s *ListsStore) AddUserToList(ctx context.Context, listID, userID uuid.UUID) error {
+	_, err := s.AddUserToListReturning(ctx, listID, userID)
+	return err
+}
+
+// AddUserToListReturning adds a user to a list and reports whether a new
+// membership row was actually created (false when the user was already a
+// member). Callers use this to emit list.user.added events only for genuine
+// additions, keeping static lists consistent with dynamic recompute.
+func (s *ListsStore) AddUserToListReturning(ctx context.Context, listID, userID uuid.UUID) (bool, error) {
 	stmt := `
 	INSERT INTO list_users (user_id, list_id)
 	VALUES ($1, $2)
-	ON CONFLICT (user_id, list_id) DO NOTHING`
+	ON CONFLICT (user_id, list_id) DO NOTHING
+	RETURNING user_id`
 
-	_, err := s.db.ExecContext(ctx, stmt, userID, listID)
-	return err
+	var inserted uuid.UUID
+	err := s.db.GetContext(ctx, &inserted, stmt, userID, listID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (s *ListsStore) DeleteList(ctx context.Context, projectID, listID uuid.UUID) error {

--- a/internal/store/subjects/lists_test.go
+++ b/internal/store/subjects/lists_test.go
@@ -443,6 +443,37 @@ func TestGetPublishedRule_NilWhenDraftOnly(t *testing.T) {
 	require.Nil(t, result, "draft-only list should not return a published rule")
 }
 
+func TestAddUserToListReturning(t *testing.T) {
+	t.Parallel()
+
+	db := NewContainerStore(t)
+	projectID := uuid.New()
+	ctx := context.Background()
+
+	listID, err := db.CreateList(ctx, List{
+		ProjectID: projectID,
+		Name:      "Membership List",
+		Type:      ListTypeStatic,
+	})
+	require.NoError(t, err)
+
+	userID, err := db.CreateUser(ctx, projectID, ptr.To("member@example.com"), nil, []byte(`{}`), nil, nil, []ExternalIDParam{{Source: "default", ExternalID: "member"}})
+	require.NoError(t, err)
+
+	// First insert genuinely adds the membership row: callers use this to gate
+	// emitting list.user.added so static-list imports stay consistent with
+	// dynamic recompute.
+	inserted, err := db.AddUserToListReturning(ctx, listID, userID)
+	require.NoError(t, err)
+	require.True(t, inserted, "first add should report a new membership row")
+
+	// Re-adding the same user is a no-op (ON CONFLICT DO NOTHING) and must
+	// report false so no duplicate list.user.added event is emitted.
+	inserted, err = db.AddUserToListReturning(ctx, listID, userID)
+	require.NoError(t, err)
+	require.False(t, inserted, "re-adding an existing member should report no new row")
+}
+
 func TestDuplicateList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Journeys can already be triggered from events, schedules, and the API. This adds a first-class **list** entrance trigger so users no longer have to hand-wire list membership events.

In the journey editor there's now a **"Start from a list"** trigger: pick a list, choose whether users enter when they **join** or **leave** it, and optionally **exit the journey when they leave the list** (on by default for the join direction). This delivers the common membership-mirroring behavior — enrol on join, auto-exit on leave — while still supporting "enrol when a user leaves a list" (e.g. win-back) and the usual multiple/concurrent entry toggles.

## How it works

The list trigger reuses the existing event-entrance pipeline:

- **Entry** maps to the `list.user.added` / `list.user.removed` membership events. The list is matched **authoritatively by `list_id` in the backend** rather than a generated rule, so a `list.user.added` for list A never enrols a journey configured for list B.
- **Auto-exit on leave** is new: the entrance also registers the *opposite* membership event as an `'exit'` dependency, and a new consumer path completes the user's active runs for that entrance. This is an external-signal exit, distinct from the in-flow exit step.

## Changes

**Backend**
- Migration: add a `kind` (`'enter'`/`'exit'`) column to `journey_version_step_events`; version-copy statements carry it.
- Journey store: kind-aware `SetJourneyStepEventDependencies`, new `ListEventJourneyExitDependencies`, user-scoped `CompleteUserJourneyEntryStates`.
- `oapi.EntranceStepData`: `list_id`, `list_direction`, `exit_on_leave`.
- Journey save: derive enter+exit events from the list trigger and register both dependencies.
- Consumer: filter entry by `list_id` for list triggers; complete the user's runs on the matching leave event.

**Consistency**
- Static/CSV list imports now emit `list.user.added` after commit, so list triggers fire for static lists too — previously only dynamic list recompute emitted membership events.

**Frontend**
- New "Start from a list" trigger card and entrance editor config (list picker, join/leave direction, exit-on-leave toggle, multiple/concurrent entries), with describe and validation support.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- New unit test for enter/exit event derivation (`journeys_list_trigger_test.go`).
- Container-backed Postgres tests pass: `TestJourneysStoreEventDependencies` (migration + changed signature), `TestImportListUsers` (changed import path).
- Console `tsc --noEmit` and `eslint` clean.

## Notes / follow-ups

- List triggers default to single entry (`multiple=false`), consistent with event triggers; users can enable "Multiple entries" for full membership-mirroring re-enrolment.