### PR TITLE
ci(cla): stop running CLA check on PR close

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize]
 
 permissions:
   actions: write


### PR DESCRIPTION
## Why

The `CLA Assistant` workflow intermittently fails on PR close/merge with:

```
Could not update the JSON file: ... Unable to create comment because issue is locked.
```

The cla-assistant action locks PRs after merge (`lock-pullrequest-aftermerge` defaults to `true`). On the `closed` event the action then tries to update its CLA comment + signatures JSON on the now-locked PR, which GitHub rejects. Open/synchronize runs are unaffected, so only close/merge runs (e.g. the `RC v0.1.0` release PR) go red.

## Change

Drop `closed` from the `pull_request_target` trigger types. CLA gating only matters while a PR is open, so there's no reason to run on close. This keeps the post-merge lock behavior intact while removing the failing write.

Ref: failing run https://github.com/lunogram/platform/actions/runs/27969165822