### PR TITLE
ci(cla): bump create-github-app-token to v3 (Node 24)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.SIGNBOT9000_APP_ID }}
           private-key: ${{ secrets.SIGNBOT9000_SECRET }}


### PR DESCRIPTION
## Why

The `CLA Assistant` workflow emits a Node 20 deprecation annotation on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/create-github-app-token@v1`, `cla-assistant/github-action@…`

## Change

Bump `actions/create-github-app-token` from `@v1` to `@v3`, which targets Node 24 natively.

### Compatibility

Our usage passes `app-id`, `private-key`, `owner`, `repositories` — all unchanged across the v2/v3 majors.

- **v2.0.0** breaking change only removed the long-deprecated input *aliases* (`app_id`, `private_key`, `skip_token_revoke`); we already use the hyphenated required forms.
- **v3.0.0** breaking changes are removal of custom proxy handling (we don't use `HTTP(S)_PROXY` on GitHub-hosted runners) and a self-hosted runner minimum of v2.327.1 (we run on `ubuntu-latest`). Neither applies here.

### Note on cla-assistant/github-action

`cla-assistant/github-action` carries the same Node 20 warning, but the pinned `v2.6.1` is its **latest release** (Sept 2024) — there's no newer version to move to. Left as-is; that annotation will remain until upstream ships a Node 24 build.