### PR TITLE
ci(release): publish OpenAPI specs as release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Publish the OpenAPI specs as release assets so the SDK repos can pin a
+  # release tag and generate their clients from a stable, versioned spec.
+  openapi-specs:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stage OpenAPI specs
+        run: |
+          mkdir -p dist-spec
+          cp internal/http/controllers/v1/client/oapi/resources.yml dist-spec/client.yaml
+          cp internal/http/controllers/v1/management/oapi/resources.yml dist-spec/management.yaml
+
+      - name: Upload specs to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" dist-spec/client.yaml dist-spec/management.yaml --clobber
+
   renderer:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Publishes the client and management OpenAPI specs as assets on each tagged release (`client.yaml`, `management.yaml`), so the SDK repos can pin a release tag and regenerate their clients from a stable, versioned spec.

Part of moving the SDKs to spec-driven codegen. Until a release is cut, SDKs pin a branch/commit ref via raw.githubusercontent and vendor the snapshot — no release required to develop.