### PR TITLE
fix(client/tests): repair main CI — duplicate type + own-scope event tests

### DIFF
--- a/internal/http/controllers/v1/client/inbox_idor_test.go
+++ b/internal/http/controllers/v1/client/inbox_idor_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/lunogram/platform/internal/pubsub"
 	"github.com/lunogram/platform/internal/pubsub/schemas"
 	"github.com/lunogram/platform/internal/rbac"
 	"github.com/lunogram/platform/internal/store/subjects"
@@ -17,17 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
-
-// capturingPublisher records every published message so a controller test can
-// assert on what was sent downstream without a real broker.
-type capturingPublisher struct {
-	messages []any
-}
-
-func (p *capturingPublisher) Publish(_ context.Context, _ schemas.Subject, v any, _ ...pubsub.PublishOption) error {
-	p.messages = append(p.messages, v)
-	return nil
-}
 
 // newInboxController wires an InboxController over an in-memory RBAC engine that
 // grants the actor the "client" project role (which carries inbox-create) and a
@@ -67,8 +55,9 @@ func postInboxMessage(t *testing.T, srv *InboxController, ctx context.Context, s
 
 func publishedIdentifiers(t *testing.T, pub *capturingPublisher) []subjects.ExternalIDParam {
 	t.Helper()
-	require.Len(t, pub.messages, 1, "exactly one inbox message should be published")
-	msg, ok := pub.messages[0].(schemas.InboxMessage)
+	captured := pub.captured()
+	require.Len(t, captured, 1, "exactly one inbox message should be published")
+	msg, ok := captured[0].Value.(schemas.InboxMessage)
 	require.True(t, ok, "published value should be a schemas.InboxMessage")
 	return msg.Identifiers
 }

--- a/internal/http/controllers/v1/client/ownscope_helpers_test.go
+++ b/internal/http/controllers/v1/client/ownscope_helpers_test.go
@@ -63,7 +63,20 @@ func (tc *testClientController) withCapturingPublisher() *capturingPublisher {
 func (tc *testClientController) ownDataActor(t *testing.T, orgID, projectID uuid.UUID, subject, source string) *rbac.Actor {
 	t.Helper()
 
-	actor := rbac.NewActor(rbac.ActorEndUser, uuid.New().String(),
+	// Provision a real, unconstrained auth method and use its id as the actor
+	// identity, so per-grant create-constraint enforcement (which looks the method
+	// up by the actor id and fails closed on a missing row) resolves to a live
+	// method — mirroring how a credential-backed end user exists in prod.
+	method, err := tc.mgmt.CreateAuthMethod(t.Context(), projectID, management.CreateAuthMethodInput{
+		Type: management.MethodTypeAPIKey,
+		Name: "own-data test method",
+		Role: rbac.ProjectClient,
+	})
+	if err != nil {
+		t.Fatalf("create auth method: %v", err)
+	}
+
+	actor := rbac.NewActor(rbac.ActorEndUser, method.ID.String(),
 		rbac.WithOrganizationID(orgID),
 		rbac.WithProjectID(projectID),
 		rbac.WithSubject(subject, source),
@@ -83,7 +96,18 @@ func (tc *testClientController) ownDataActor(t *testing.T, orgID, projectID uuid
 func (tc *testClientController) allDataActor(t *testing.T, orgID, projectID uuid.UUID) *rbac.Actor {
 	t.Helper()
 
-	actor := rbac.NewActor(rbac.ActorEndUser, uuid.New().String(),
+	// See ownDataActor: the actor id must be a live auth method so per-grant
+	// create-constraint enforcement resolves instead of failing closed.
+	method, err := tc.mgmt.CreateAuthMethod(t.Context(), projectID, management.CreateAuthMethodInput{
+		Type: management.MethodTypeAPIKey,
+		Name: "all-data test method",
+		Role: rbac.ProjectClient,
+	})
+	if err != nil {
+		t.Fatalf("create auth method: %v", err)
+	}
+
+	actor := rbac.NewActor(rbac.ActorEndUser, method.ID.String(),
 		rbac.WithOrganizationID(orgID),
 		rbac.WithProjectID(projectID),
 		rbac.WithSubject("trusted-subject", "https://idp.example"),


### PR DESCRIPTION
## Why

`main` CI is red: both the **lint** and **tests** jobs fail to compile the `internal/http/controllers/v1/client` test binary. This is fallout from two PRs in the access-policies stack merging independently — and the build failure was masking a second, real test break underneath.

## What

**1. Duplicate `capturingPublisher` (the build break)**
The type was declared in *both* `inbox_idor_test.go` and `ownscope_helpers_test.go`. Dropped the simpler duplicate from `inbox_idor_test.go` and pointed its one consumer (`publishedIdentifiers`) at the canonical `captured()` / `capturedMessage` API.

**2. Own-scope event tests fail closed (masked by the above)**
`ownDataActor` / `allDataActor` built actors with a random UUID and **no auth-method row**. After per-grant create-constraint enforcement landed (#261), `CreateConstraints.Enforce` looks the method up by the actor id and *fails closed on a missing row* (`sql.ErrNoRows` → 500) — breaking every `PostUserEvents` own/all-data test. Now both helpers provision a real, unconstrained auth method and use its id as the actor identity, mirroring `actorContext`.

## Verification
- `go vet ./...` clean
- full `internal/http/controllers/v1/client` suite passes (`go test -count=1`)