### PR TITLE
test(broadcasts): drop stale campaign ProviderID from enterprise tests

### DIFF
--- a/internal/http/controllers/v1/management/broadcasts_enterprise_test.go
+++ b/internal/http/controllers/v1/management/broadcasts_enterprise_test.go
@@ -70,7 +70,9 @@ func newBroadcastTestEnv(t *testing.T) broadcastTestEnv {
 	})
 	require.NoError(t, err)
 
-	providerID, err := mgmtState.ProvidersStore.CreateProvider(ctx, management.Provider{
+	// A provider must exist for the channel so the broadcast can resolve one
+	// at send time; campaigns no longer reference a provider directly.
+	_, err = mgmtState.ProvidersStore.CreateProvider(ctx, management.Provider{
 		ProjectID: projectID,
 		Module:    "test",
 		Channels:  management.Channels{"email"},
@@ -80,10 +82,9 @@ func newBroadcastTestEnv(t *testing.T) broadcastTestEnv {
 	require.NoError(t, err)
 
 	campaignID, err := mgmtState.CampaignsStore.CreateCampaign(ctx, management.Campaign{
-		ProjectID:  projectID,
-		Name:       "Broadcast Campaign",
-		Channel:    "email",
-		ProviderID: &providerID,
+		ProjectID: projectID,
+		Name:      "Broadcast Campaign",
+		Channel:   "email",
 	})
 	require.NoError(t, err)
 

--- a/internal/pubsub/consumer/broadcasts_enterprise_test.go
+++ b/internal/pubsub/consumer/broadcasts_enterprise_test.go
@@ -83,7 +83,9 @@ func setupBroadcastsTest(t *testing.T) (
 func seedBroadcast(t *testing.T, ctx graceful.Context, mgmt *management.State, usrs *subjects.State, projectID uuid.UUID) (broadcastID, campaignID, listID uuid.UUID) {
 	t.Helper()
 
-	providerID, err := mgmt.ProvidersStore.CreateProvider(ctx, management.Provider{
+	// A provider must exist for the channel so the broadcast can resolve one
+	// at send time; campaigns no longer reference a provider directly.
+	_, err := mgmt.ProvidersStore.CreateProvider(ctx, management.Provider{
 		ProjectID: projectID,
 		Module:    "test",
 		Channels:  management.Channels{"email"},
@@ -93,10 +95,9 @@ func seedBroadcast(t *testing.T, ctx graceful.Context, mgmt *management.State, u
 	require.NoError(t, err)
 
 	campaignID, err = mgmt.CampaignsStore.CreateCampaign(ctx, management.Campaign{
-		ProjectID:  projectID,
-		Name:       "Test Campaign",
-		Channel:    "email",
-		ProviderID: &providerID,
+		ProjectID: projectID,
+		Name:      "Test Campaign",
+		Channel:   "email",
 	})
 	require.NoError(t, err)
 
@@ -228,12 +229,11 @@ func TestBroadcastProcessHandler_CampaignNoProvider(t *testing.T) {
 
 	pub := pubsub.NewPublisher(jet, string(ns))
 
-	// Create a campaign without a provider.
+	// Create a campaign with no provider configured for its channel.
 	campaignID, err := mgmtState.CampaignsStore.CreateCampaign(ctx, management.Campaign{
 		ProjectID: projectID,
 		Name:      "No Provider Campaign",
 		Channel:   "email",
-		// ProviderID intentionally nil
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
The `campaigns.provider_id` column was removed in migration `1764106044_drop_campaign_provider_id`, and the `management.Campaign` struct no longer has a `ProviderID` field — but the two enterprise broadcast tests still set it:

- `internal/http/controllers/v1/management/broadcasts_enterprise_test.go`
- `internal/pubsub/consumer/broadcasts_enterprise_test.go`

This broke `go vet -tags enterprise` / the enterprise test build for both packages. CI does not run the `enterprise` build tag, so it went unnoticed (it surfaced while working on the invites/org-membership branches, which sit on top of this).

### Fix
Remove the obsolete `ProviderID` references. The test provider is still created so a provider exists for the channel at send time; campaigns now resolve a provider by channel rather than by a stored id. Also dropped the now-stale `// ProviderID intentionally nil` comment.

### Verification
- `go vet -tags enterprise ./internal/http/controllers/v1/management/` ✅
- `go vet -tags enterprise ./internal/pubsub/consumer/` ✅
- `go build ./...` ✅
- `gofmt` clean