### PR TITLE
refactor(console): reland oapiClient view-layer migration (supersedes #241)

### DIFF
--- a/console/src/components/locale/select.tsx
+++ b/console/src/components/locale/select.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState, useEffect, useMemo } from "react"
 import { LocaleContext, ProjectContext } from "@/contexts"
-import api from "@/api"
+import { oapiClient } from "@/oapi/client"
 import type { Locale } from "@/types"
 
 import { Plus, Check, ChevronsUpDown } from "lucide-react"
@@ -53,12 +53,14 @@ export function LocaleSelect({ onChange }: LocaleSelectProps) {
         const fetchFilteredLocales = async () => {
             setIsLoading(true)
 
-            const { results } = await api.locales.search(project.id, {
-                search: searchQuery,
-                limit: 5,
+            const { data } = await oapiClient.GET("/api/admin/projects/{projectID}/locales", {
+                params: {
+                    path: { projectID: project.id },
+                    query: { search: searchQuery, limit: 5 },
+                },
             })
 
-            setLocales(results)
+            setLocales(data?.results ?? [])
             setIsLoading(false)
         }
 
@@ -98,10 +100,14 @@ export function LocaleSelect({ onChange }: LocaleSelectProps) {
         setIsCreating(true)
         try {
             const label = resolveLocaleName(newLocaleKey)
-            const newLocale = await api.locales.create(project.id, {
-                key: newLocaleKey,
-                label,
-            })
+            const { data: newLocale } = await oapiClient.POST(
+                "/api/admin/projects/{projectID}/locales",
+                {
+                    params: { path: { projectID: project.id } },
+                    body: { key: newLocaleKey, label },
+                },
+            )
+            if (!newLocale) return
 
             setLocaleSelection((prev) => ({
                 ...prev,

--- a/console/src/components/media-manager/MediaManager.tsx
+++ b/console/src/components/media-manager/MediaManager.tsx
@@ -23,6 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { ProjectContext } from "@/contexts"
 import api from "@/api"
+import { oapiClient } from "@/oapi/client"
 import type { Image } from "@/types"
 import { cn } from "@/utils"
 
@@ -61,11 +62,20 @@ export function MediaManager({ open, onOpenChange, onSelect }: MediaManagerProps
         async (query?: string) => {
             setLoading(true)
             try {
-                const result = await api.images.search(project.id, {
-                    search: query || undefined,
-                    limit: 50,
-                })
-                setImages(result.results ?? result.data ?? [])
+                const { data, error } = await oapiClient.GET(
+                    "/api/admin/projects/{projectID}/documents",
+                    {
+                        params: {
+                            path: { projectID: project.id },
+                            query: {
+                                search: query || undefined,
+                                limit: 50,
+                            } as { limit: number; search?: string },
+                        },
+                    },
+                )
+                if (error) throw error
+                setImages((data?.results ?? []) as Image[])
                 setHasLoaded(true)
             } catch {
                 setImages([])
@@ -161,7 +171,11 @@ export function MediaManager({ open, onOpenChange, onSelect }: MediaManagerProps
             e.stopPropagation()
             setDeletingId(imageId)
             try {
-                await api.images.delete(project.id, imageId)
+                const { error } = await oapiClient.DELETE(
+                    "/api/admin/projects/{projectID}/documents/{documentID}",
+                    { params: { path: { projectID: project.id, documentID: imageId } } },
+                )
+                if (error) throw error
                 setImages((prev) => prev.filter((img) => img.id !== imageId))
             } catch {
                 // Delete failed – swallow for now

--- a/console/src/lib/path-suggestions.ts
+++ b/console/src/lib/path-suggestions.ts
@@ -1,0 +1,90 @@
+import { oapiClient } from "@/oapi/client"
+import type { UUID } from "@/types/common"
+import type { VariableSuggestions } from "@/types"
+
+/**
+ * Fetches variable path suggestions for a project by aggregating the various
+ * subject schema endpoints. Organization-related schemas are optional and fall
+ * back to empty arrays when the endpoints are unavailable.
+ *
+ * Replaces the legacy `api.projects.pathSuggestions` aggregator; uses the typed
+ * OpenAPI client throughout.
+ */
+export async function fetchPathSuggestions(projectId: UUID): Promise<VariableSuggestions> {
+    const path = { projectID: projectId }
+
+    const { data: userEvents } = await oapiClient.GET(
+        "/api/admin/projects/{projectID}/subjects/user/events/schema",
+        { params: { path } },
+    )
+    const eventPaths = (userEvents?.results ?? []).map((event) => ({
+        ...event,
+        schema: event.schema ?? [],
+    })) as VariableSuggestions["eventPaths"]
+
+    const { data: users } = await oapiClient.GET(
+        "/api/admin/projects/{projectID}/subjects/users/schema",
+        { params: { path } },
+    )
+    const userPaths = (users?.results ?? []) as VariableSuggestions["userPaths"]
+
+    let scheduledPaths: VariableSuggestions["scheduledPaths"] = []
+    try {
+        const { data } = await oapiClient.GET(
+            "/api/admin/projects/{projectID}/subjects/user/scheduled/schema",
+            { params: { path } },
+        )
+        scheduledPaths = (data?.results ?? []).map((s) => ({
+            ...s,
+            schema: s.schema ?? [],
+        })) as VariableSuggestions["scheduledPaths"]
+    } catch (error) {
+        console.debug("Failed to fetch scheduled schemas:", error)
+    }
+
+    let organizationEventPaths: VariableSuggestions["organizationEventPaths"] = []
+    try {
+        const { data } = await oapiClient.GET(
+            "/api/admin/projects/{projectID}/subjects/organization/events/schema",
+            { params: { path } },
+        )
+        organizationEventPaths = (data?.results ?? []).map((event) => ({
+            ...event,
+            schema: event.schema ?? [],
+        })) as VariableSuggestions["organizationEventPaths"]
+    } catch (error) {
+        console.debug("Failed to fetch organization event schemas:", error)
+    }
+
+    let organizationUserPaths: VariableSuggestions["organizationUserPaths"] = []
+    try {
+        const { data } = await oapiClient.GET(
+            "/api/admin/projects/{projectID}/subjects/organizations/users/schema",
+            { params: { path } },
+        )
+        organizationUserPaths = (data?.results ??
+            []) as VariableSuggestions["organizationUserPaths"]
+    } catch (error) {
+        console.debug("Failed to fetch organization user schemas:", error)
+    }
+
+    let organizationPaths: VariableSuggestions["organizationPaths"] = []
+    try {
+        const { data } = await oapiClient.GET(
+            "/api/admin/projects/{projectID}/subjects/organizations/schema",
+            { params: { path } },
+        )
+        organizationPaths = (data?.results ?? []) as VariableSuggestions["organizationPaths"]
+    } catch (error) {
+        console.debug("Failed to fetch organization schemas:", error)
+    }
+
+    return {
+        eventPaths,
+        userPaths,
+        scheduledPaths,
+        organizationEventPaths,
+        organizationUserPaths,
+        organizationPaths,
+    }
+}

--- a/console/src/validation/settings/api-key-dialog.ts
+++ b/console/src/validation/settings/api-key-dialog.ts
@@ -1,0 +1,9 @@
+import * as z from "zod"
+
+export const apiKeySchema = z.object({
+    name: z.string().min(1, "Name is required"),
+    description: z.string().optional(),
+    role: z.string().optional(),
+})
+
+export type ApiKeyFormValues = z.infer<typeof apiKeySchema>

--- a/console/src/views/campaign/CampaignVariableContext.tsx
+++ b/console/src/views/campaign/CampaignVariableContext.tsx
@@ -8,7 +8,7 @@ import {
 } from "react"
 import type { VariableGroup } from "@/views/journey/JourneyVariableContext"
 import { CampaignContext, ProjectContext } from "@/contexts"
-import api from "@/api"
+import { fetchPathSuggestions } from "@/lib/path-suggestions"
 import type { VariableSuggestions } from "@/types"
 
 interface CampaignVariableContextValue {
@@ -107,8 +107,7 @@ export function CampaignVariableProvider({ children }: PropsWithChildren) {
     // Fetch user schema paths once per project
     useEffect(() => {
         let cancelled = false
-        api.projects
-            .pathSuggestions(project.id)
+        fetchPathSuggestions(project.id)
             .then((s) => {
                 if (!cancelled) setSuggestions(s)
             })

--- a/console/src/views/campaign/template/mail/editor/hooks/useSendTestEmail.ts
+++ b/console/src/views/campaign/template/mail/editor/hooks/useSendTestEmail.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useState } from "react"
 import { toast } from "sonner"
-import { AxiosError } from "axios"
-import api from "@/api"
+import { oapiClient } from "@/oapi/client"
 import { TemplateWorkflowContext } from "../../../contexts"
 
 interface UseSendTestEmailOptions {
@@ -50,17 +49,29 @@ export function useSendTestEmail({
                 return
             }
 
-            await api.campaigns.templates.sendTest(projectId, campaignId, templateId, {
-                to: email,
-                props: previewProps,
-            })
+            const { error } = await oapiClient.POST(
+                "/api/admin/projects/{projectID}/campaigns/{campaignID}/templates/{templateID}/test",
+                {
+                    params: {
+                        path: {
+                            projectID: projectId,
+                            campaignID: campaignId,
+                            templateID: templateId,
+                        },
+                    },
+                    body: {
+                        to: email,
+                        props: previewProps,
+                    },
+                },
+            )
+            if (error) {
+                toast.error(error.detail || "Failed to send test email")
+                return
+            }
             toast.success(`Test email sent to ${email}`)
-        } catch (err) {
-            const detail =
-                err instanceof AxiosError && typeof err.response?.data?.detail === "string"
-                    ? err.response.data.detail
-                    : null
-            toast.error(detail || "Failed to send test email")
+        } catch {
+            toast.error("Failed to send test email")
         } finally {
             setSending(false)
         }

--- a/console/src/views/campaign/template/text/useSendTestSMS.ts
+++ b/console/src/views/campaign/template/text/useSendTestSMS.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useState } from "react"
 import { toast } from "sonner"
-import { AxiosError } from "axios"
-import api from "@/api"
+import { oapiClient } from "@/oapi/client"
 import type { User } from "@/types"
 import { TemplateWorkflowContext } from "../contexts"
 
@@ -50,17 +49,29 @@ export function useSendTestSMS({
                     return
                 }
 
-                await api.campaigns.templates.sendTest(projectId, campaignId, templateId, {
-                    to: phoneNumber,
-                    ...(user ? { props: { user } } : {}),
-                })
+                const { error } = await oapiClient.POST(
+                    "/api/admin/projects/{projectID}/campaigns/{campaignID}/templates/{templateID}/test",
+                    {
+                        params: {
+                            path: {
+                                projectID: projectId,
+                                campaignID: campaignId,
+                                templateID: templateId,
+                            },
+                        },
+                        body: {
+                            to: phoneNumber,
+                            ...(user ? { props: { user } } : {}),
+                        },
+                    },
+                )
+                if (error) {
+                    toast.error(error.detail || "Failed to send test SMS")
+                    return
+                }
                 toast.success(`Test SMS sent to ${phoneNumber}`)
-            } catch (err) {
-                const detail =
-                    err instanceof AxiosError && typeof err.response?.data?.detail === "string"
-                        ? err.response.data.detail
-                        : null
-                toast.error(detail || "Failed to send test SMS")
+            } catch {
+                toast.error("Failed to send test SMS")
             } finally {
                 setSending(false)
             }

--- a/console/src/views/journey/JourneyUserSelectionModal.tsx
+++ b/console/src/views/journey/JourneyUserSelectionModal.tsx
@@ -22,7 +22,7 @@ import { getRandomColor } from "@/lib/colors"
 import { useDebounceControl } from "@/hooks"
 import oapiClient from "@/oapi/client"
 import type { User } from "@/types"
-import api from "@/api"
+import { fetchPathSuggestions } from "@/lib/path-suggestions"
 import type { UUID } from "@/types/common"
 
 const PAGE_SIZE = 25
@@ -134,8 +134,7 @@ export function UserSelectionModal({
         }
 
         let cancelled = false
-        api.projects
-            .pathSuggestions(projectId)
+        fetchPathSuggestions(projectId)
             .then((suggestions) => {
                 if (cancelled) return
                 const match = suggestions.eventPaths.find((e) => e.name === eventName)

--- a/console/src/views/journey/JourneyVariableContext.tsx
+++ b/console/src/views/journey/JourneyVariableContext.tsx
@@ -12,7 +12,7 @@ import type { JourneyNodeData } from "./editor/JourneyEditor.types"
 import type { VariableSuggestions } from "@/types"
 import { getUpstreamDataKeys } from "./editor/JourneyEditor.utils"
 import { ProjectContext } from "@/contexts"
-import api from "@/api"
+import { fetchPathSuggestions } from "@/lib/path-suggestions"
 
 export interface Variable {
     /** Liquid-compatible path, e.g. "user.email" or "journey.my_key.amount" */
@@ -61,8 +61,7 @@ export function JourneyVariableProvider({
     // Fetch user/event path suggestions once per project
     useEffect(() => {
         let cancelled = false
-        api.projects
-            .pathSuggestions(project.id)
+        fetchPathSuggestions(project.id)
             .then((s) => {
                 if (!cancelled) setSuggestions(s)
             })

--- a/console/src/views/project/GettingStarted.tsx
+++ b/console/src/views/project/GettingStarted.tsx
@@ -14,8 +14,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ProjectContext } from "@/contexts"
 import { useNavigate, useParams } from "react-router"
 import type { UUID } from "@/types/common"
+import type { Project } from "@/types"
 import { NIL } from "uuid"
-import api from "@/api"
+import { oapiClient } from "@/oapi/client"
+import type { components } from "@/oapi/management.generated"
 import { cn } from "@/utils"
 import { t } from "i18next"
 import { Puzzle } from "lucide-react"
@@ -28,8 +30,10 @@ export default function ProjectGettingStarted() {
 
     useEffect(() => {
         const loadProject = async () => {
-            const projectState = await api.projects.get(projectId)
-            setProject(projectState)
+            const { data } = await oapiClient.GET("/api/admin/projects/{projectID}", {
+                params: { path: { projectID: projectId } },
+            })
+            if (data) setProject(data as Project)
         }
         loadProject().catch(console.error)
     }, [setProject, projectId])
@@ -43,13 +47,19 @@ export default function ProjectGettingStarted() {
     async function createOnboardingJourney() {
         setIsJourneyLoading(true)
         try {
-            const journey = await api.journeys.create(projectId, {
-                name: "Onboarding",
-                description: "Getting started with your first journey",
-                template_id: "onboarding",
-                status: "draft",
-            })
-            await navigate(`/projects/${projectId}/journeys/${journey.id}`)
+            const { data: journey } = await oapiClient.POST(
+                "/api/admin/projects/{projectID}/journeys",
+                {
+                    params: { path: { projectID: projectId } },
+                    body: {
+                        name: "Onboarding",
+                        description: "Getting started with your first journey",
+                        template_id: "onboarding",
+                        status: "draft",
+                    } as components["schemas"]["CreateJourney"],
+                },
+            )
+            if (journey) await navigate(`/projects/${projectId}/journeys/${journey.id}`)
         } finally {
             setIsJourneyLoading(false)
         }

--- a/console/src/views/project/ProjectOnboardingGettingStarted.tsx
+++ b/console/src/views/project/ProjectOnboardingGettingStarted.tsx
@@ -9,7 +9,8 @@ import {
     CardHeader,
     CardTitle,
 } from "@/components/ui/card"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
+import type { components } from "@/oapi/management.generated"
 import type { UUID } from "@/types/common"
 import { useState } from "react"
 import { NIL } from "uuid"
@@ -24,20 +25,30 @@ export default function ProjectOnboardingGettingStarted() {
     async function createOnboardingJourney() {
         setIsJourneyLoading(true)
         try {
-            const journeys = await api.journeys.search(projectId, { limit: 1 })
-            if (journeys.results.length > 0) {
-                await navigate(`/projects/${projectId}/journeys/${journeys.results[0].id}`)
+            const { data: journeys } = await oapiClient.GET(
+                "/api/admin/projects/{projectID}/journeys",
+                { params: { path: { projectID: projectId }, query: { limit: 1 } } },
+            )
+            const existing = journeys?.results ?? []
+            if (existing.length > 0) {
+                await navigate(`/projects/${projectId}/journeys/${existing[0].id}`)
                 return
             }
 
-            const journey = await api.journeys.create(projectId, {
-                name: "Onboarding",
-                description: "Getting started with your first journey",
-                template_id: "onboarding",
-                status: "draft",
-            })
+            const { data: journey } = await oapiClient.POST(
+                "/api/admin/projects/{projectID}/journeys",
+                {
+                    params: { path: { projectID: projectId } },
+                    body: {
+                        name: "Onboarding",
+                        description: "Getting started with your first journey",
+                        template_id: "onboarding",
+                        status: "draft",
+                    } as components["schemas"]["CreateJourney"],
+                },
+            )
 
-            await navigate(`/projects/${projectId}/journeys/${journey.id}`)
+            if (journey) await navigate(`/projects/${projectId}/journeys/${journey.id}`)
         } finally {
             setIsJourneyLoading(false)
         }

--- a/console/src/views/project/ProjectOnboardingIntegration.tsx
+++ b/console/src/views/project/ProjectOnboardingIntegration.tsx
@@ -3,8 +3,7 @@ import { useNavigate, useParams } from "react-router"
 import { useTranslation } from "react-i18next"
 import { ChevronLeft } from "lucide-react"
 import { NIL } from "uuid"
-import api from "../../api"
-import oapiClient from "@/oapi/client"
+import { oapiClient } from "@/oapi/client"
 import { ProjectContext } from "../../contexts"
 import { useResolver } from "../../hooks"
 import { snakeToTitle, hasCourierProvider } from "../../utils"
@@ -20,6 +19,7 @@ import {
 } from "@/components/ui/card"
 import { isEnterprise } from "@/config/enterprise"
 import type { UUID } from "@/types/common"
+import type { Project } from "../../types"
 import type { ProviderMeta } from "@/oapi/client"
 
 export default function ProjectOnboardingIntegration() {
@@ -95,8 +95,11 @@ export default function ProjectOnboardingIntegration() {
                             project={project}
                             meta={meta}
                             onChange={async () => {
-                                const updatedProject = await api.projects.get(projectId)
-                                setProject(updatedProject)
+                                const { data: updatedProject } = await oapiClient.GET(
+                                    "/api/admin/projects/{projectID}",
+                                    { params: { path: { projectID: projectId } } },
+                                )
+                                if (updatedProject) setProject(updatedProject as Project)
                                 const step =
                                     isEnterprise && (await hasCourierProvider(projectId))
                                         ? "domain"

--- a/console/src/views/project/ProjectOnboardingUsers.tsx
+++ b/console/src/views/project/ProjectOnboardingUsers.tsx
@@ -13,8 +13,8 @@ import {
 } from "@/components/ui/card"
 import { UserImportForm } from "@/components/ui/user-import-dialog"
 import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 import type { UUID } from "@/types/common"
-import type { User } from "../../types"
 import { useContext, useState } from "react"
 import { NIL } from "uuid"
 import { ProjectContext } from "@/contexts"
@@ -29,7 +29,7 @@ export default function ProjectOnboardingUsers() {
     const [skipLoading, setSkipLoading] = useState(false)
 
     async function createInitialUser() {
-        const admin = await api.admins.whoami()
+        const { data: admin } = await oapiClient.GET("/api/admin/tenant/whoami")
         if (!admin) return
 
         let fullName
@@ -37,16 +37,17 @@ export default function ProjectOnboardingUsers() {
             fullName = admin.last_name ? admin.first_name + " " + admin.last_name : admin.first_name
         }
 
-        await api.users.create(projectId, {
-            identifier: [
-                { source: "admin", external_id: admin.id },
-            ] as unknown as User["identifier"],
-            data: {
-                full_name: fullName,
-                admin: true,
+        await oapiClient.POST("/api/admin/projects/{projectID}/subjects/users", {
+            params: { path: { projectID: projectId } },
+            body: {
+                identifier: [{ source: "admin", external_id: admin.id }],
+                data: {
+                    full_name: fullName,
+                    admin: true,
+                },
+                email: admin.email,
+                timezone: project.timezone,
             },
-            email: admin.email,
-            timezone: project.timezone,
         })
     }
 

--- a/console/src/views/project/Projects.tsx
+++ b/console/src/views/project/Projects.tsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useMemo, useState } from "react"
+import { useCallback, useContext, useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 import { useResolver } from "../../hooks"
 import type { Project } from "../../types"
 import { Button } from "@/components/ui/button"
@@ -17,8 +17,13 @@ export function Projects() {
     const navigate = useNavigate()
     const { t } = useTranslation()
     const [preferences] = useContext(PreferencesContext)
-    const [response] = useResolver(api.projects.all)
-    const projects = response?.results
+    const [response] = useResolver(
+        useCallback(async () => {
+            const { data } = await oapiClient.GET("/api/admin/projects")
+            return data ?? null
+        }, []),
+    )
+    const projects = response?.results as Project[] | undefined
 
     const recents = useMemo(() => {
         const recents = getRecentProjects()

--- a/console/src/views/settings/EventSchemas.tsx
+++ b/console/src/views/settings/EventSchemas.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Search, Zap, MoreHorizontal, Trash2, ChevronRight } from "lucide-react"
 import { ProjectContext } from "../../contexts"
 import { useResolver } from "../../hooks"
-import oapiClient from "../../oapi/client"
-import { client } from "../../api"
+import { oapiClient } from "../../oapi/client"
 import type { components } from "../../oapi/management.generated"
 
 import { Input } from "@/components/ui/input"
@@ -82,14 +81,11 @@ export default function EventSchemas() {
 
     const [scheduledResult, , reloadScheduled] = useResolver(
         useCallback(async () => {
-            try {
-                const { data } = await client.get<{ results: EventWithSchema[] }>(
-                    `/admin/projects/${project.id}/subjects/user/scheduled/schema`,
-                )
-                return data
-            } catch {
-                return { results: [] as EventWithSchema[] }
-            }
+            const { data } = await oapiClient.GET(
+                "/api/admin/projects/{projectID}/subjects/user/scheduled/schema",
+                { params: { path: { projectID: project.id } } },
+            )
+            return data ?? { results: [] as EventWithSchema[] }
         }, [project.id]),
     )
 
@@ -152,8 +148,13 @@ export default function EventSchemas() {
                 },
             )
         } else {
-            await client.delete(
-                `/admin/projects/${project.id}/subjects/user/scheduled/schema/${event.id}`,
+            await oapiClient.DELETE(
+                "/api/admin/projects/{projectID}/subjects/user/scheduled/schema/{scheduledID}",
+                {
+                    params: {
+                        path: { projectID: project.id, scheduledID: event.id },
+                    },
+                },
             )
         }
         await reload()

--- a/console/src/views/settings/Locales.tsx
+++ b/console/src/views/settings/Locales.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Globe, Plus, Search, MoreHorizontal } from "lucide-react"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 import { ProjectContext } from "../../contexts"
 import { useResolver } from "../../hooks"
 import type { Locale } from "../../types"
@@ -45,7 +45,10 @@ export default function Locales() {
 
     const [result, , reload] = useResolver(
         useCallback(async () => {
-            return await api.locales.search(project.id, { limit: 100 })
+            const { data } = await oapiClient.GET("/api/admin/projects/{projectID}/locales", {
+                params: { path: { projectID: project.id }, query: { limit: 100 } },
+            })
+            return data ?? null
         }, [project.id]),
     )
 
@@ -63,7 +66,9 @@ export default function Locales() {
 
     const handleDeleteLocale = async (locale: Locale) => {
         if (!confirm(t("locale.delete_confirmation"))) return
-        await api.locales.delete(project.id, locale.id)
+        await oapiClient.DELETE("/api/admin/projects/{projectID}/locales/{localeID}", {
+            params: { path: { projectID: project.id, localeID: locale.id } },
+        })
         await reload()
     }
 
@@ -72,7 +77,10 @@ export default function Locales() {
         setIsCreating(true)
         try {
             const label = resolveLocaleName(selectedLocaleKey)
-            await api.locales.create(project.id, { key: selectedLocaleKey, label })
+            await oapiClient.POST("/api/admin/projects/{projectID}/locales", {
+                params: { path: { projectID: project.id } },
+                body: { key: selectedLocaleKey, label },
+            })
             await reload()
             setOpen(false)
             setSelectedLocaleKey(undefined)

--- a/console/src/views/settings/ProjectSettings.tsx
+++ b/console/src/views/settings/ProjectSettings.tsx
@@ -3,7 +3,7 @@ import { ProjectContext } from "../../contexts"
 import { toast } from "sonner"
 import ProjectForm from "../project/ProjectForm"
 import { useTranslation } from "react-i18next"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 import { AlertTriangle } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -29,7 +29,10 @@ export default function ProjectSettings() {
     const deleteProject = async () => {
         setIsDeleting(true)
         try {
-            await api.projects.delete(project.id)
+            const { error } = await oapiClient.DELETE("/api/admin/projects/{projectID}", {
+                params: { path: { projectID: project.id } },
+            })
+            if (error) throw error
             window.location.href = "/"
         } catch {
             toast.error(t("delete_project_error"))

--- a/console/src/views/users/UserDetailJourneys.tsx
+++ b/console/src/views/users/UserDetailJourneys.tsx
@@ -6,7 +6,7 @@ import { ProjectContext, UserContext } from "../../contexts"
 import { PreferencesContext } from "@/contexts/PreferencesContext"
 import { useResolver } from "../../hooks"
 import { formatDate } from "../../utils"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -44,10 +44,16 @@ export default function UserDetailJourneys() {
 
     const [result] = useResolver(
         useCallback(async () => {
-            return await api.users.journeys.search(project.id, user.id, {
-                limit,
-                offset: (page - 1) * limit,
-            })
+            const { data } = await oapiClient.GET(
+                "/api/admin/projects/{projectID}/subjects/users/{userID}/journeys",
+                {
+                    params: {
+                        path: { projectID: project.id, userID: user.id },
+                        query: { limit, offset: (page - 1) * limit },
+                    },
+                },
+            )
+            return data ?? null
         }, [project.id, user.id, page]),
     )
 

--- a/console/src/views/users/UserDetailSubscriptions.tsx
+++ b/console/src/views/users/UserDetailSubscriptions.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner"
 import { ProjectContext, UserContext } from "../../contexts"
 import { useResolver } from "../../hooks"
 import { snakeToTitle } from "../../utils"
-import api from "../../api"
+import { oapiClient } from "@/oapi/client"
 import type { SubscriptionParams, SubscriptionState } from "../../types"
 import type { UUID } from "@/types/common"
 
@@ -42,7 +42,16 @@ export default function UserDetailSubscriptions() {
 
     const [search, , reload] = useResolver(
         useCallback(async () => {
-            return await api.users.subscriptions(project.id, user.id, { limit: 100 })
+            const { data } = await oapiClient.GET(
+                "/api/admin/projects/{projectID}/subjects/users/{userID}/subscriptions",
+                {
+                    params: {
+                        path: { projectID: project.id, userID: user.id },
+                        query: { limit: 100 },
+                    },
+                },
+            )
+            return data ?? null
         }, [project.id, user.id]),
     )
 
@@ -60,19 +69,31 @@ export default function UserDetailSubscriptions() {
         if (!confirmAction) return
 
         if (confirmAction.type === "toggle" && confirmAction.subscriptionId) {
-            await api.users.updateSubscriptions(project.id, user.id, [
+            await oapiClient.PATCH(
+                "/api/admin/projects/{projectID}/subjects/users/{userID}/subscriptions",
                 {
-                    subscription_id: confirmAction.subscriptionId,
-                    state: confirmAction.newState!,
+                    params: { path: { projectID: project.id, userID: user.id } },
+                    body: [
+                        {
+                            subscription_id: confirmAction.subscriptionId,
+                            state: confirmAction.newState!,
+                        },
+                    ],
                 },
-            ])
+            )
         } else if (confirmAction.type === "unsubscribe_all") {
             const params: SubscriptionParams[] =
                 subscriptions?.map((item) => ({
                     subscription_id: item.subscription_id,
                     state: "unsubscribed" as SubscriptionState,
                 })) ?? []
-            await api.users.updateSubscriptions(project.id, user.id, params)
+            await oapiClient.PATCH(
+                "/api/admin/projects/{projectID}/subjects/users/{userID}/subscriptions",
+                {
+                    params: { path: { projectID: project.id, userID: user.id } },
+                    body: params,
+                },
+            )
         }
 
         await reload()

--- a/console/src/views/users/rules/RuleBuilder.tsx
+++ b/console/src/views/users/rules/RuleBuilder.tsx
@@ -5,7 +5,7 @@ import { useController } from "react-hook-form"
 import { useCallback, useContext, useMemo } from "react"
 import { ProjectContext } from "../../../contexts"
 import { useResolver } from "../../../hooks"
-import api from "../../../api"
+import { fetchPathSuggestions } from "@/lib/path-suggestions"
 import { snakeToTitle } from "../../../utils"
 import { emptySuggestions, VariablesContext } from "./RuleHelpers"
 import type { VariableGroup } from "@/views/journey/JourneyVariableContext"
@@ -33,7 +33,7 @@ export default function RuleBuilder({
 }: RuleBuilderParams) {
     const [{ id: projectId }] = useContext(ProjectContext)
     const [suggestions] = useResolver(
-        useCallback(async () => await api.projects.pathSuggestions(projectId), [projectId]),
+        useCallback(async () => await fetchPathSuggestions(projectId), [projectId]),
     )
     return (
         <VariablesContext.Provider


### PR DESCRIPTION
## Summary

This relands the salvageable part of #241. Most of #241's diff already landed on main via other PRs; merging #241 as-is would revert main's Access/clients feature and resurrect deleted files. The genuinely useful net delta is the **view-layer migration from the legacy API client to the generated OpenAPI client (`oapiClient`)** on files that main has *not* touched since #241 forked (merge-base `1683f7e0`).

For those files, taking #241's version applies only the client migration with zero conflict. This PR relands exactly that subset.

## Files relanded (20)

These were migrated only by #241; main still runs them on the legacy client:

- `console/src/components/locale/select.tsx`
- `console/src/components/media-manager/MediaManager.tsx`
- `console/src/lib/path-suggestions.ts`
- `console/src/validation/settings/api-key-dialog.ts`
- `console/src/views/campaign/CampaignVariableContext.tsx`
- `console/src/views/campaign/template/mail/editor/hooks/useSendTestEmail.ts`
- `console/src/views/campaign/template/text/useSendTestSMS.ts`
- `console/src/views/journey/JourneyUserSelectionModal.tsx`
- `console/src/views/journey/JourneyVariableContext.tsx`
- `console/src/views/project/GettingStarted.tsx`
- `console/src/views/project/ProjectOnboardingGettingStarted.tsx`
- `console/src/views/project/ProjectOnboardingIntegration.tsx`
- `console/src/views/project/ProjectOnboardingUsers.tsx`
- `console/src/views/project/Projects.tsx`
- `console/src/views/settings/EventSchemas.tsx`
- `console/src/views/settings/Locales.tsx`
- `console/src/views/settings/ProjectSettings.tsx`
- `console/src/views/users/UserDetailJourneys.tsx`
- `console/src/views/users/UserDetailSubscriptions.tsx`
- `console/src/views/users/rules/RuleBuilder.tsx`

## Verification

Verified **tsc-clean** against main's baseline:

- Baseline (`origin/main`, `tsc -p tsconfig.app.json --noEmit`): 125 pre-existing errors.
- With this reland: 124 errors. **Zero new type errors** introduced; this reland actually fixes one pre-existing error (`MediaManager.tsx` `SearchResult<Image>.data`).
- ESLint on the 20 relanded files: clean (no errors, no new warnings).

## Files that could NOT be cleanly relanded (dropped, 12)

These were part of #241's view migration but depend on #241's version of deferred/conflict files (notably the migrated `console/src/types.ts` and the generated OpenAPI symbols). On main's legacy `types.ts`, #241's casts/assignments to `Template` / `User` / `Journey` / `Campaign` / `List` / `Project` / `JourneyStepMap` no longer overlap, producing new `TS2352`/`TS2322`/`TS2345` errors. They were reverted to main's version to keep this PR tsc-clean and need a manual re-migration on top of main:

- `console/src/components/app-sidebar.tsx`
- `console/src/views/campaign/template/Content.tsx`
- `console/src/views/campaign/template/Review.tsx`
- `console/src/views/campaign/template/Template.tsx`
- `console/src/views/campaign/template/UserSelection.tsx`
- `console/src/views/campaign/template/mail/editor/hooks/useTemplatePersistence.ts`
- `console/src/views/journey/components/JourneyEditorToolbar.tsx`
- `console/src/views/journey/editor/JourneyEditor.tsx`
- `console/src/views/journey/hooks/useJourneyPersistence.ts`
- `console/src/views/journey/steps/Campaign.tsx`
- `console/src/views/users/ListDetail.tsx`
- `console/src/views/users/UserLookup.tsx`

Supersedes #241.
