### PR TITLE
fix(release): download WASM modules to their module path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: wasm-modules
-          path: internal
+          path: internal/integrations/modules
 
       - name: Download console dist
         uses: actions/download-artifact@v8


### PR DESCRIPTION
The `goreleaser` pre-hook expects `internal/integrations/modules/*.wasm`, but the release workflow downloaded the `wasm-modules` artifact into `internal/`. `upload-artifact` roots the archive at the glob's least-common-ancestor directory, so the files land one level deep — and the hook fails with "WASM modules not found".

This aligns the download `path:` with the upload path, mirroring the working console-dist step.

Caught by a dry-run release (`v0.1.0-rc.0`): before this fix `goreleaser` failed at the pre-hook and `openapi-specs` was skipped; after it, all four jobs pass and the release carries `client.yaml` + `management.yaml`.