### PR TITLE
fix(scheduled): only report "Sending" for events that are due

### DIFF
--- a/internal/store/subjects/scheduled.go
+++ b/internal/store/subjects/scheduled.go
@@ -681,7 +681,7 @@ func (s *ScheduledStore) ListUserSchedules(ctx context.Context, projectID, userI
 		us.occurrence, COALESCE(us.data, '{}'::jsonb) AS data, us.paused_at, us.created_at, us.updated_at,
 		EXISTS (
 			SELECT 1 FROM user_scheduled_events use
-			WHERE use.user_schedule_id = us.id AND use.fired_at IS NULL
+			WHERE use.user_schedule_id = us.id AND use.fired_at IS NULL AND use.fire_at <= NOW()
 		) AS has_pending_events,
 		COUNT(*) OVER () AS total_count
 	FROM user_schedules us
@@ -1288,7 +1288,7 @@ func (s *ScheduledStore) ListOrganizationSchedules(ctx context.Context, projectI
 		os.occurrence, COALESCE(os.data, '{}'::jsonb) AS data, os.paused_at, os.created_at, os.updated_at,
 		EXISTS (
 			SELECT 1 FROM organization_scheduled_events ose
-			WHERE ose.organization_schedule_id = os.id AND ose.fired_at IS NULL
+			WHERE ose.organization_schedule_id = os.id AND ose.fired_at IS NULL AND ose.fire_at <= NOW()
 		) AS has_pending_events,
 		COUNT(*) OVER () AS total_count
 	FROM organization_schedules os

--- a/internal/store/subjects/scheduled_test.go
+++ b/internal/store/subjects/scheduled_test.go
@@ -646,20 +646,33 @@ func TestListUserSchedulesHasPendingEvents(t *testing.T) {
 	_, err = db.CreateUserSchedule(ctx, userID, scheduleID, &futureTime, nil, nil, json.RawMessage(`{}`))
 	require.NoError(t, err)
 
-	// While the generated event is unfired, the schedule reports pending events.
+	// An unfired event whose fire_at is still in the future is NOT "sending":
+	// has_pending_events only reflects events that are actually due. (Regression:
+	// recurring schedules pre-generate the next occurrence's event, which kept the
+	// "Sending" badge lit indefinitely.)
 	items, _, err := db.ListUserSchedules(ctx, projectID, userID, store.Pagination{Limit: 10, Offset: 0})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.False(t, items[0].HasPendingEvents)
+
+	events, err := db.ListPendingScheduledEventsForUser(ctx, userID, scheduleID)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	// Once the event is due (fire_at <= now), the schedule reports pending events.
+	pastTime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Microsecond)
+	_, err = db.ScheduledStore.db.ExecContext(ctx,
+		`UPDATE user_scheduled_events SET fire_at = $1 WHERE id = $2`,
+		pastTime, events[0].ID)
+	require.NoError(t, err)
+
+	items, _, err = db.ListUserSchedules(ctx, projectID, userID, store.Pagination{Limit: 10, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	require.True(t, items[0].HasPendingEvents)
 
-	// Firing every event must clear the flag (regression: the badge previously
-	// relied on scheduled_at <= now and stayed lit forever).
-	events, err := db.ListPendingScheduledEventsForUser(ctx, userID, scheduleID)
-	require.NoError(t, err)
-	require.NotEmpty(t, events)
-	for _, e := range events {
-		require.NoError(t, db.MarkScheduledEventFired(ctx, e.ID))
-	}
+	// Firing the event clears the flag.
+	require.NoError(t, db.MarkScheduledEventFired(ctx, events[0].ID))
 
 	items, _, err = db.ListUserSchedules(ctx, projectID, userID, store.Pagination{Limit: 10, Offset: 0})
 	require.NoError(t, err)
@@ -1185,19 +1198,33 @@ func TestListOrganizationSchedulesHasPendingEvents(t *testing.T) {
 	_, err = db.CreateOrganizationSchedule(ctx, orgID, scheduleID, &futureTime, nil, nil, json.RawMessage(`{}`))
 	require.NoError(t, err)
 
-	// While the generated event is unfired, the schedule reports pending events.
+	// An unfired event whose fire_at is still in the future is NOT "sending":
+	// has_pending_events only reflects events that are actually due. (Regression:
+	// recurring schedules pre-generate the next occurrence's event, which kept the
+	// "Sending" badge lit indefinitely.)
 	items, _, err := db.ListOrganizationSchedules(ctx, projectID, orgID, store.Pagination{Limit: 10, Offset: 0})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.False(t, items[0].HasPendingEvents)
+
+	events, err := db.ListPendingOrgScheduledEventsForOrg(ctx, orgID, scheduleID)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	// Once the event is due (fire_at <= now), the schedule reports pending events.
+	pastTime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Microsecond)
+	_, err = db.ScheduledStore.db.ExecContext(ctx,
+		`UPDATE organization_scheduled_events SET fire_at = $1 WHERE id = $2`,
+		pastTime, events[0].ID)
+	require.NoError(t, err)
+
+	items, _, err = db.ListOrganizationSchedules(ctx, projectID, orgID, store.Pagination{Limit: 10, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	require.True(t, items[0].HasPendingEvents)
 
-	// Firing every event must clear the flag.
-	events, err := db.ListPendingOrgScheduledEventsForOrg(ctx, orgID, scheduleID)
-	require.NoError(t, err)
-	require.NotEmpty(t, events)
-	for _, e := range events {
-		require.NoError(t, db.MarkOrgScheduledEventFired(ctx, e.ID))
-	}
+	// Firing the event clears the flag.
+	require.NoError(t, db.MarkOrgScheduledEventFired(ctx, events[0].ID))
 
 	items, _, err = db.ListOrganizationSchedules(ctx, projectID, orgID, store.Pagination{Limit: 10, Offset: 0})
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

A user reported a scheduled message stuck in **"Sending"** state in the console (`.../users/<id>/scheduled`). Investigation (incl. inspecting the lab DB) showed the schedule was actually healthy — it just *looked* stuck.

The "anniversary" record was a recurring schedule (`interval = 1 year`):

| field | value |
|---|---|
| `scheduled_at` | 2027-03-28 (next occurrence) |
| `occurrence` | 1 |
| its single pending event's `fire_at` | **2027-03-28** (9 months out) |
| `fired_at` | null |

So there was one unfired event — but it isn't due until next year. The console renders the "Sending" badge purely from `has_pending_events`, which was computed as *"any unfired event exists"*. Recurring schedules **pre-generate the next occurrence's event** the moment they advance (`AdvanceAndGenerateUserScheduleEvents` → `generateScheduledEvents`), so a recurring schedule **always** has an unfired future event — and therefore perpetually shows "Sending", even while idle.

## Fix

Scope `has_pending_events` to events that are actually **due** in `ListUserSchedules` and `ListOrganizationSchedules`:

```sql
WHERE ... AND fired_at IS NULL AND fire_at <= NOW()
```

This matches the existing scan-due predicate (`ScanDueScheduledEvents`) and the badge's own tooltip ("could take up to 1 minute to process"). The badge now reflects an event being **actively delivered**, not one queued for a future occurrence.

No frontend change is required — the badge keys solely off this field, and nothing else in the codebase consumes it.

## Not changed (by design)

The first occurrence of a recurring schedule is `anchor + 1×interval` (a schedule "every year starting 2026-03-28" first fires 2027-03-28, not 2026-03-28). Confirmed with the reporter that this anchor semantics is intended, so `computeNextOccurrence` is left as-is.

## Testing

- Updated `TestListUserSchedulesHasPendingEvents` / `TestListOrganizationSchedulesHasPendingEvents` to assert a future-dated unfired event is **not** "Sending", becomes "Sending" once `fire_at <= now`, and clears once fired.
- `go test ./internal/store/subjects/ -run Schedul` — all green.