### PR TITLE
fix(console): re-enable campaign create after toggling transactional off

### DIFF
--- a/console/src/views/campaign/NewCampaign.tsx
+++ b/console/src/views/campaign/NewCampaign.tsx
@@ -105,7 +105,9 @@ export default function NewCampaign() {
         )
 
         if (!hasValidSelection) {
-            form.setValue("subscription_id", filteredSubscriptions[0].id)
+            form.setValue("subscription_id", filteredSubscriptions[0].id, {
+                shouldValidate: true,
+            })
         }
     }, [isTransactional, subscriptionsLoading, filteredSubscriptions, subscriptionId, form])
 
@@ -323,7 +325,9 @@ export default function NewCampaign() {
                                         onCheckedChange={(checked) => {
                                             field.onChange(checked)
                                             if (checked) {
-                                                form.setValue("subscription_id", "")
+                                                form.setValue("subscription_id", "", {
+                                                    shouldValidate: true,
+                                                })
                                             }
                                         }}
                                     />


### PR DESCRIPTION
## Problem

When creating a campaign, enabling the **Transactional** toggle and then disabling it again left the **Create** button disabled — even though a subscription was selected.

## Cause

In `NewCampaign.tsx`:

1. Enabling the toggle clears `subscription_id` to `""`.
2. Disabling it triggers the auto-select effect, which restores a subscription via `form.setValue("subscription_id", ...)`.

`form.setValue` does **not** re-run validation by default, so `form.formState.isValid` stayed stale at `false` while a valid subscription was actually selected — keeping the Create button disabled.

## Fix

Pass `{ shouldValidate: true }` to the `form.setValue` calls that set `subscription_id` programmatically (the auto-select effect and the toggle-on clear), so the form revalidates and `formState.isValid` reflects the real state.

## Testing

- `npx tsc --noEmit` passes.
- Manual: select a subscription → toggle Transactional on → toggle off → Create button is enabled again.