### PR TITLE
fix(console): show the email itself in the small Journey preview

### DIFF
--- a/console/src/components/preview.tsx
+++ b/console/src/components/preview.tsx
@@ -83,7 +83,7 @@ function EmailPreviewContent({
     }, [data?.code?.source])
 
     return (
-        <EmailFrame subject={data.subject} fromName={data.from?.name} labels={labels}>
+        <EmailFrame subject={data.subject} fromName={data.from?.name} size={size} labels={labels}>
             <Iframe content={compiledHtml} allowScroll={size !== "small"} />
         </EmailFrame>
     )

--- a/console/src/components/preview.tsx
+++ b/console/src/components/preview.tsx
@@ -82,9 +82,24 @@ function EmailPreviewContent({
         }
     }, [data?.code?.source])
 
+    // In the small thumbnail (e.g. the Journey Send node) the Gmail-style
+    // header chrome doesn't fit and just looks broken — show the rendered
+    // email itself instead, clipped to the thumbnail height.
+    if (size === "small") {
+        return compiledHtml ? (
+            <div className="h-full w-full overflow-hidden bg-white">
+                <Iframe content={compiledHtml} allowScroll={false} width="100%" />
+            </div>
+        ) : (
+            <div className="flex h-full w-full items-center justify-center bg-white text-sm italic text-gray-400">
+                {labels.noContent}
+            </div>
+        )
+    }
+
     return (
-        <EmailFrame subject={data.subject} fromName={data.from?.name} size={size} labels={labels}>
-            <Iframe content={compiledHtml} allowScroll={size !== "small"} />
+        <EmailFrame subject={data.subject} fromName={data.from?.name} labels={labels}>
+            <Iframe content={compiledHtml} allowScroll />
         </EmailFrame>
     )
 }

--- a/console/src/components/preview/EmailFrame.tsx
+++ b/console/src/components/preview/EmailFrame.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react"
-import clsx from "clsx"
 
 function ArchiveIcon() {
     return (
@@ -94,12 +93,6 @@ export interface EmailFrameProps {
     emptyLabel?: string
     /** Override container classes (defaults to rounded card style) */
     className?: string
-    /**
-     * Layout density. "small" renders a condensed header (smaller type, tighter
-     * padding, action icons hidden) so the frame fits inside a thumbnail-sized
-     * container such as the Journey editor's Send node.
-     */
-    size?: "small" | "large"
     /** Translated labels for static UI text */
     labels?: {
         noSubject?: string
@@ -116,7 +109,6 @@ export function EmailFrame({
     children,
     emptyLabel,
     className,
-    size = "large",
     labels,
 }: EmailFrameProps) {
     const noSubjectLabel = labels?.noSubject ?? "No subject"
@@ -128,7 +120,6 @@ export function EmailFrame({
             hour: "numeric",
             minute: "2-digit",
         })
-    const compact = size === "small"
 
     return (
         <div
@@ -137,92 +128,57 @@ export function EmailFrame({
                 "bg-white border rounded-lg w-full overflow-hidden flex flex-col flex-1"
             }
         >
-            <div className={compact ? "px-3 py-2.5" : "px-6 py-4"}>
-                <div
-                    className={clsx(
-                        "flex items-start justify-between",
-                        compact ? "mb-2" : "mb-4",
-                    )}
-                >
-                    <h1
-                        className={clsx(
-                            "font-normal text-gray-900 flex-1 pr-4",
-                            compact ? "text-sm leading-snug truncate" : "text-[22px]",
-                        )}
-                    >
+            <div className="px-6 py-4">
+                <div className="flex items-start justify-between mb-4">
+                    <h1 className="text-[22px] font-normal text-gray-900 flex-1 pr-4">
                         {subject || <span className="text-gray-400 italic">{noSubjectLabel}</span>}
                     </h1>
-                    {!compact && (
-                        <div
-                            className="flex items-center gap-1 text-gray-600 flex-shrink-0"
-                            aria-hidden="true"
-                        >
-                            <span className="p-2 hover:bg-gray-100 rounded-full">
-                                <ArchiveIcon />
-                            </span>
-                            <span className="p-2 hover:bg-gray-100 rounded-full">
-                                <ReportIcon />
-                            </span>
-                            <span className="p-2 hover:bg-gray-100 rounded-full">
-                                <TrashIcon />
-                            </span>
-                        </div>
-                    )}
+                    <div className="flex items-center gap-1 text-gray-600 flex-shrink-0" aria-hidden="true">
+                        <span className="p-2 hover:bg-gray-100 rounded-full">
+                            <ArchiveIcon />
+                        </span>
+                        <span className="p-2 hover:bg-gray-100 rounded-full">
+                            <ReportIcon />
+                        </span>
+                        <span className="p-2 hover:bg-gray-100 rounded-full">
+                            <TrashIcon />
+                        </span>
+                    </div>
                 </div>
 
-                <div className={clsx("flex items-start", compact ? "gap-2" : "gap-3")}>
-                    <div
-                        className={clsx(
-                            "rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center text-white font-medium flex-shrink-0",
-                            compact ? "w-7 h-7 text-xs" : "w-10 h-10",
-                        )}
-                    >
+                <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center text-white font-medium flex-shrink-0">
                         {fromName ? fromName.charAt(0).toUpperCase() : "?"}
                     </div>
 
                     <div className="flex-1 min-w-0">
                         <div className="flex items-baseline gap-2 mb-1">
-                            <span
-                                className={clsx(
-                                    "font-medium text-gray-900 truncate",
-                                    compact ? "text-xs" : "text-sm",
-                                )}
-                            >
+                            <span className="font-medium text-gray-900 text-sm">
                                 {fromName || (
                                     <span className="text-gray-400 italic">{unknownSenderLabel}</span>
                                 )}
                             </span>
-                            <span className="text-xs text-gray-500 flex-shrink-0">{displayTime}</span>
+                            <span className="text-xs text-gray-500">{displayTime}</span>
                         </div>
-                        <div
-                            className="flex items-center gap-1 text-xs text-gray-600"
-                            aria-hidden="true"
-                        >
+                        <div className="flex items-center gap-1 text-xs text-gray-600" aria-hidden="true">
                             <span>to me</span>
                             <span className="hover:bg-gray-100 px-1 rounded">
                                 <ChevronDownIcon />
                             </span>
                         </div>
                         {replyTo && (
-                            <div className="text-xs text-gray-500 mt-1 truncate">
-                                Reply-To: {replyTo}
-                            </div>
+                            <div className="text-xs text-gray-500 mt-1">Reply-To: {replyTo}</div>
                         )}
                     </div>
 
-                    {!compact && (
-                        <div
-                            className="flex items-center gap-1 flex-shrink-0"
-                            aria-hidden="true"
-                        >
-                            <span className="p-2 hover:bg-gray-100 rounded-full">
-                                <ReplyIcon />
-                            </span>
-                            <span className="p-2 hover:bg-gray-100 rounded-full">
-                                <MoreVertIcon />
-                            </span>
-                        </div>
-                    )}
+                    <div className="flex items-center gap-1 flex-shrink-0" aria-hidden="true">
+                        <span className="p-2 hover:bg-gray-100 rounded-full">
+                            <ReplyIcon />
+                        </span>
+                        <span className="p-2 hover:bg-gray-100 rounded-full">
+                            <MoreVertIcon />
+                        </span>
+                    </div>
                 </div>
             </div>
 

--- a/console/src/components/preview/EmailFrame.tsx
+++ b/console/src/components/preview/EmailFrame.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import clsx from "clsx"
 
 function ArchiveIcon() {
     return (
@@ -93,6 +94,12 @@ export interface EmailFrameProps {
     emptyLabel?: string
     /** Override container classes (defaults to rounded card style) */
     className?: string
+    /**
+     * Layout density. "small" renders a condensed header (smaller type, tighter
+     * padding, action icons hidden) so the frame fits inside a thumbnail-sized
+     * container such as the Journey editor's Send node.
+     */
+    size?: "small" | "large"
     /** Translated labels for static UI text */
     labels?: {
         noSubject?: string
@@ -109,6 +116,7 @@ export function EmailFrame({
     children,
     emptyLabel,
     className,
+    size = "large",
     labels,
 }: EmailFrameProps) {
     const noSubjectLabel = labels?.noSubject ?? "No subject"
@@ -120,6 +128,7 @@ export function EmailFrame({
             hour: "numeric",
             minute: "2-digit",
         })
+    const compact = size === "small"
 
     return (
         <div
@@ -128,57 +137,92 @@ export function EmailFrame({
                 "bg-white border rounded-lg w-full overflow-hidden flex flex-col flex-1"
             }
         >
-            <div className="px-6 py-4">
-                <div className="flex items-start justify-between mb-4">
-                    <h1 className="text-[22px] font-normal text-gray-900 flex-1 pr-4">
+            <div className={compact ? "px-3 py-2.5" : "px-6 py-4"}>
+                <div
+                    className={clsx(
+                        "flex items-start justify-between",
+                        compact ? "mb-2" : "mb-4",
+                    )}
+                >
+                    <h1
+                        className={clsx(
+                            "font-normal text-gray-900 flex-1 pr-4",
+                            compact ? "text-sm leading-snug truncate" : "text-[22px]",
+                        )}
+                    >
                         {subject || <span className="text-gray-400 italic">{noSubjectLabel}</span>}
                     </h1>
-                    <div className="flex items-center gap-1 text-gray-600 flex-shrink-0" aria-hidden="true">
-                        <span className="p-2 hover:bg-gray-100 rounded-full">
-                            <ArchiveIcon />
-                        </span>
-                        <span className="p-2 hover:bg-gray-100 rounded-full">
-                            <ReportIcon />
-                        </span>
-                        <span className="p-2 hover:bg-gray-100 rounded-full">
-                            <TrashIcon />
-                        </span>
-                    </div>
+                    {!compact && (
+                        <div
+                            className="flex items-center gap-1 text-gray-600 flex-shrink-0"
+                            aria-hidden="true"
+                        >
+                            <span className="p-2 hover:bg-gray-100 rounded-full">
+                                <ArchiveIcon />
+                            </span>
+                            <span className="p-2 hover:bg-gray-100 rounded-full">
+                                <ReportIcon />
+                            </span>
+                            <span className="p-2 hover:bg-gray-100 rounded-full">
+                                <TrashIcon />
+                            </span>
+                        </div>
+                    )}
                 </div>
 
-                <div className="flex items-start gap-3">
-                    <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center text-white font-medium flex-shrink-0">
+                <div className={clsx("flex items-start", compact ? "gap-2" : "gap-3")}>
+                    <div
+                        className={clsx(
+                            "rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center text-white font-medium flex-shrink-0",
+                            compact ? "w-7 h-7 text-xs" : "w-10 h-10",
+                        )}
+                    >
                         {fromName ? fromName.charAt(0).toUpperCase() : "?"}
                     </div>
 
                     <div className="flex-1 min-w-0">
                         <div className="flex items-baseline gap-2 mb-1">
-                            <span className="font-medium text-gray-900 text-sm">
+                            <span
+                                className={clsx(
+                                    "font-medium text-gray-900 truncate",
+                                    compact ? "text-xs" : "text-sm",
+                                )}
+                            >
                                 {fromName || (
                                     <span className="text-gray-400 italic">{unknownSenderLabel}</span>
                                 )}
                             </span>
-                            <span className="text-xs text-gray-500">{displayTime}</span>
+                            <span className="text-xs text-gray-500 flex-shrink-0">{displayTime}</span>
                         </div>
-                        <div className="flex items-center gap-1 text-xs text-gray-600" aria-hidden="true">
+                        <div
+                            className="flex items-center gap-1 text-xs text-gray-600"
+                            aria-hidden="true"
+                        >
                             <span>to me</span>
                             <span className="hover:bg-gray-100 px-1 rounded">
                                 <ChevronDownIcon />
                             </span>
                         </div>
                         {replyTo && (
-                            <div className="text-xs text-gray-500 mt-1">Reply-To: {replyTo}</div>
+                            <div className="text-xs text-gray-500 mt-1 truncate">
+                                Reply-To: {replyTo}
+                            </div>
                         )}
                     </div>
 
-                    <div className="flex items-center gap-1 flex-shrink-0" aria-hidden="true">
-                        <span className="p-2 hover:bg-gray-100 rounded-full">
-                            <ReplyIcon />
-                        </span>
-                        <span className="p-2 hover:bg-gray-100 rounded-full">
-                            <MoreVertIcon />
-                        </span>
-                    </div>
+                    {!compact && (
+                        <div
+                            className="flex items-center gap-1 flex-shrink-0"
+                            aria-hidden="true"
+                        >
+                            <span className="p-2 hover:bg-gray-100 rounded-full">
+                                <ReplyIcon />
+                            </span>
+                            <span className="p-2 hover:bg-gray-100 rounded-full">
+                                <MoreVertIcon />
+                            </span>
+                        </div>
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
## Problem

The email preview in the Journey editor's **Send** node looked broken. The node renders the preview inside a small ~250×200px thumbnail (`<Preview size="small">`), but it always drew the full Gmail-style chrome — 22px subject, avatar, sender row, and a full set of action icons. Crammed into the thumbnail the subject ("No subject"), sender ("Unknown sender") and timestamp wrapped onto multiple lines and the reply icon overlapped the time.

## Fix

At thumbnail size the Gmail header isn't useful — it's just chrome that doesn't fit. So for `size="small"` the email **preview now renders the compiled email itself**, clipped to the thumbnail height, which is a truer preview of what actually gets sent. The full-size preview (`EmailFrame` with the Gmail header) is unchanged.

- `EmailPreviewContent` branches on size: `small` → email body iframe only (with a "No content" fallback while empty/compiling); `large` → unchanged framed view.
- `EmailFrame` is untouched (identical to `main`).

## Scope

`size="small"` is only used by the Journey Send node (`views/journey/steps/Campaign.tsx`), so nothing else is affected.

## Testing

- `tsc --noEmit` passes for the changed files.