### PR TITLE
fix(journey): auto-assign entrance data_key so input event variables are usable

### DIFF
--- a/console/src/views/journey/editor/JourneyEditor.utils.test.ts
+++ b/console/src/views/journey/editor/JourneyEditor.utils.test.ts
@@ -1,0 +1,49 @@
+// Unit tests for the entrance data_key defaulting: entrances need a data_key for
+// their trigger ("input") event variables to be referenceable downstream as
+// `journey.<data_key>.data.*`, so we assign one automatically and backfill any
+// legacy entrances that lack one.
+
+import { describe, expect, it } from "vitest"
+
+import { defaultEntranceDataKey, stepsToNodes } from "./JourneyEditor.utils"
+import type { JourneyStepMap } from "@/types"
+
+describe("defaultEntranceDataKey", () => {
+    it("uses 'entrance' when free", () => {
+        expect(defaultEntranceDataKey([])).toBe("entrance")
+    })
+
+    it("falls back to a numbered suffix when taken", () => {
+        expect(defaultEntranceDataKey(["entrance"])).toBe("entrance_2")
+        expect(defaultEntranceDataKey(["entrance", "entrance_2"])).toBe("entrance_3")
+    })
+
+    it("ignores gaps and unrelated keys", () => {
+        expect(defaultEntranceDataKey(["entrance", "purchase", "entrance_3"])).toBe("entrance_2")
+    })
+})
+
+describe("stepsToNodes entrance data_key backfill", () => {
+    it("assigns a default data_key to entrances that lack one", () => {
+        const steps: JourneyStepMap = {
+            a: { type: "entrance", name: "Entry", x: 0, y: 0 },
+            b: { type: "gate", name: "Gate", x: 0, y: 100 },
+        }
+        const { nodes } = stepsToNodes(steps, {})
+        const entrance = nodes.find((n) => n.id === "a")
+        const gate = nodes.find((n) => n.id === "b")
+        expect(entrance?.data.data_key).toBe("entrance")
+        // Non-entrance steps are left untouched.
+        expect(gate?.data.data_key).toBeUndefined()
+    })
+
+    it("preserves an existing data_key and de-duplicates against it", () => {
+        const steps: JourneyStepMap = {
+            a: { type: "entrance", name: "Entry 1", data_key: "entrance", x: 0, y: 0 },
+            b: { type: "entrance", name: "Entry 2", x: 200, y: 0 },
+        }
+        const { nodes } = stepsToNodes(steps, {})
+        expect(nodes.find((n) => n.id === "a")?.data.data_key).toBe("entrance")
+        expect(nodes.find((n) => n.id === "b")?.data.data_key).toBe("entrance_2")
+    })
+})

--- a/console/src/views/journey/editor/JourneyEditor.utils.ts
+++ b/console/src/views/journey/editor/JourneyEditor.utils.ts
@@ -100,6 +100,21 @@ export function createEdge({ data, sourceId, targetId, path }: CreateEdgeParams)
     }
 }
 
+/**
+ * The trigger event payload captured by an entrance is only referenceable from
+ * downstream steps (gates, campaigns, …) as `journey.<data_key>.data.*`, and the
+ * backend only exposes a step's state when it has a non-empty `data_key`. Pick a
+ * readable, unique default ("entrance", "entrance_2", …) so the input event
+ * variables are available without the user having to discover the data_key field.
+ */
+export function defaultEntranceDataKey(existingKeys: Iterable<string>): string {
+    const used = new Set(existingKeys)
+    if (!used.has("entrance")) return "entrance"
+    let i = 2
+    while (used.has(`entrance_${i}`)) i++
+    return `entrance_${i}`
+}
+
 export function stepsToNodes(
     stepMap: JourneyStepMap,
     actions: {
@@ -113,6 +128,11 @@ export function stepsToNodes(
     const entries = Object.entries(stepMap)
     const nodeIds = new Set(entries.map(([id]) => id))
 
+    // Backfill a default data_key for entrances that predate auto-assignment so
+    // their input event variables surface in downstream pickers. This only fills
+    // empty keys (non-destructive) and is persisted on the next manual save.
+    const usedDataKeys = new Set(entries.map(([, s]) => s.data_key).filter((k): k is string => !!k))
+
     for (const [
         id,
         { x, y, type, data, name, data_key, children, stats, stats_at, id: stepId },
@@ -120,6 +140,13 @@ export function stepsToNodes(
         const { width, height, ...restData } = (data as Record<string, unknown>) ?? {}
         const sizeStyle =
             typeof width === "number" && typeof height === "number" ? { width, height } : undefined
+
+        let resolvedDataKey = data_key
+        if (!resolvedDataKey && type === "entrance") {
+            resolvedDataKey = defaultEntranceDataKey(usedDataKeys)
+            usedDataKeys.add(resolvedDataKey)
+        }
+
         nodes.push({
             id,
             position: { x, y },
@@ -128,7 +155,7 @@ export function stepsToNodes(
             data: {
                 type,
                 name,
-                data_key,
+                data_key: resolvedDataKey,
                 data: restData,
                 stats,
                 stats_at,

--- a/console/src/views/journey/hooks/useJourneyEditorGraph.ts
+++ b/console/src/views/journey/hooks/useJourneyEditorGraph.ts
@@ -8,7 +8,12 @@ import type { EntranceTrigger } from "../components/JourneyTriggerSetup"
 import type { JourneyEditorActionsValue } from "../editor/JourneyEditorActions"
 import type { JourneyHintsValue } from "../editor/JourneyHints"
 import type { JourneyEdge, JourneyNode } from "../editor/JourneyEditor.types"
-import { cloneNodes, getStepType, isValidJourneyConnection } from "../editor/JourneyEditor.utils"
+import {
+    cloneNodes,
+    defaultEntranceDataKey,
+    getStepType,
+    isValidJourneyConnection,
+} from "../editor/JourneyEditor.utils"
 import { useJourneyFlowHandlers } from "./useJourneyFlowHandlers"
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts"
 import { useStepEditing } from "./useStepEditing"
@@ -347,6 +352,7 @@ export function useJourneyEditorGraph({
                     data: {
                         type: "entrance",
                         name: t("entrance"),
+                        data_key: defaultEntranceDataKey([]),
                         data: { ...defaultData, trigger },
                         editing: true,
                     },

--- a/console/src/views/journey/hooks/useJourneyFlowHandlers.ts
+++ b/console/src/views/journey/hooks/useJourneyFlowHandlers.ts
@@ -87,6 +87,17 @@ export function useJourneyFlowHandlers(
                           )
                         : undefined
 
+                // An exit must target an entrance (required field). Default to the
+                // first entrance so single-entrance journeys need no manual pick.
+                let stepData = data
+                if (
+                    payload.type === "exit" &&
+                    !(stepData as { entrance_uuid?: string }).entrance_uuid
+                ) {
+                    const firstEntrance = nds.find((n) => n.data.type === "entrance")
+                    if (firstEntrance) stepData = { ...stepData, entrance_uuid: firstEntrance.id }
+                }
+
                 const newNode: JourneyNode = {
                     id: createUuid(),
                     position: { x, y },
@@ -95,7 +106,7 @@ export function useJourneyFlowHandlers(
                         type: payload.type,
                         name,
                         data_key,
-                        data,
+                        data: stepData,
                         ...(isSticky ? { width: 275, height: 150 } : {}),
                     },
                     ...(isSticky ? { style: { width: 275, height: 150 } } : {}),

--- a/console/src/views/journey/hooks/useJourneyFlowHandlers.ts
+++ b/console/src/views/journey/hooks/useJourneyFlowHandlers.ts
@@ -3,7 +3,11 @@ import { addEdge, type Connection, MarkerType, type ReactFlowInstance } from "@x
 import { useTranslation } from "react-i18next"
 import { createUuid } from "@/utils"
 import { DATA_FORMAT, STEP_STYLE } from "./JourneyEditor.constants"
-import { getStepType, isValidJourneyConnection } from "../editor/JourneyEditor.utils"
+import {
+    defaultEntranceDataKey,
+    getStepType,
+    isValidJourneyConnection,
+} from "../editor/JourneyEditor.utils"
 import type { JourneyEdge, JourneyNode } from "../editor/JourneyEditor.types"
 
 export function useJourneyFlowHandlers(
@@ -74,6 +78,15 @@ export function useJourneyFlowHandlers(
                     if (entranceCount > 0) name = `${t("entrance")} ${entranceCount + 1}`
                 }
 
+                // Give entrances a default data_key so their trigger event data is
+                // immediately referenceable downstream as `journey.<data_key>.data.*`.
+                const data_key =
+                    payload.type === "entrance"
+                        ? defaultEntranceDataKey(
+                              nds.map((n) => n.data.data_key).filter((k): k is string => !!k),
+                          )
+                        : undefined
+
                 const newNode: JourneyNode = {
                     id: createUuid(),
                     position: { x, y },
@@ -81,6 +94,7 @@ export function useJourneyFlowHandlers(
                     data: {
                         type: payload.type,
                         name,
+                        data_key,
                         data,
                         ...(isSticky ? { width: 275, height: 150 } : {}),
                     },


### PR DESCRIPTION
## Problem

In the Journey editor, when configuring a **gate** (or any downstream step), the "Search variables…" picker only showed the **User** section — the triggering **input event**'s variables (e.g. `patient_id`, `resource_id`, `occurred_at`) were missing, so they couldn't be referenced in conditions.

## Root cause

A step's event variables only surface downstream when that step has a `data_key`:
- Frontend: `getUpstreamDataKeys` skips ancestor nodes without a `data_key`.
- Backend: `GetJourneyEntryData` only exposes step state `WHERE data_key IS NOT NULL`, and the trigger event is referenced as `journey.<data_key>.data.*`.

Entrance steps were never assigned a `data_key` automatically — it was a manual, easily-missed sidebar field. With it empty, the entrance's captured input event was never exposed, so the picker showed only the always-present **User** group.

## Fix

Give entrances a readable, unique default `data_key` (`entrance`, `entrance_2`, …):

- **At creation** — both the drag-and-drop path (`useJourneyFlowHandlers.onDrop`) and the initial trigger-setup path (`createEntranceFromSetup`).
- **On load (backfill)** — `stepsToNodes` fills a default for entrances that predate this. It only fills empty keys (non-destructive — nothing referenced the entrance before, since it had no key) and persists on the next manual save.

A shared `defaultEntranceDataKey()` helper de-duplicates against existing keys.

With a `data_key` present, `getUpstreamDataKeys` returns the entrance and `JourneyVariableContext` renders its input-event group, so fields like `journey.entrance.data.patient_id` become selectable in gate/campaign value pickers.

## Tests

Added `JourneyEditor.utils.test.ts` covering `defaultEntranceDataKey` (default, numbered fallback, gap/unrelated-key handling) and the `stepsToNodes` backfill (assigns to entrances only, preserves + de-dupes existing keys). Full console suite: 70 passing. `tsc` + eslint clean.