### PR TITLE
fix(http): run rate limiter after authentication

### DIFF
--- a/internal/http/controllers/v1/http.go
+++ b/internal/http/controllers/v1/http.go
@@ -89,18 +89,20 @@ func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *st
 	// Mount management routes with JWT+API Key auth
 	mgmtoapi.HandlerWithOptions(mgmtController, mgmtoapi.ChiServerOptions{
 		BaseRouter: router,
+		// The generated wrapper applies these middlewares by wrapping forward
+		// (handler = mw(handler)), so the LAST entry becomes the outermost and
+		// runs FIRST. RateLimit is therefore listed before the validator so it
+		// runs *after* authentication and keys on the resolved auth method; the
+		// budget is shared with the client API, so a key cannot get a separate
+		// allowance per surface.
 		Middlewares: []mgmtoapi.MiddlewareFunc{
+			http.RateLimit(limiter, cfg.RateLimit.PerMinute, time.Minute, cfg.RateLimit.TrustedProxyHops, mgmtoapi.WriteProblem),
 			mgmtoapi.Validator(mgmtSpec, openapi3filter.Options{
 				AuthenticationFunc: auth.Middleware(
 					auth.WithJWT(cfg.Auth, mgmtStores),
 					auth.WithKey(mgmtStores, auth.SurfaceManagement),
 				),
 			}),
-			// Runs after the validator (and thus after authentication) so the
-			// limiter keys on the resolved auth method. The budget is shared
-			// with the client API, so a key cannot get a separate allowance per
-			// surface.
-			http.RateLimit(limiter, cfg.RateLimit.PerMinute, time.Minute, cfg.RateLimit.TrustedProxyHops, mgmtoapi.WriteProblem),
 		},
 	})
 
@@ -110,7 +112,10 @@ func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *st
 		r.Options("/api/client/*", func(w nethttp.ResponseWriter, r *nethttp.Request) {})
 		clientoapi.HandlerWithOptions(clientController, clientoapi.ChiServerOptions{
 			BaseRouter: r,
+			// Listed before the validator so it runs *after* authentication —
+			// see the management mount above for why the order is reversed.
 			Middlewares: []clientoapi.MiddlewareFunc{
+				http.RateLimit(limiter, cfg.RateLimit.PerMinute, time.Minute, cfg.RateLimit.TrustedProxyHops, clientoapi.WriteProblem),
 				clientoapi.Validator(clientSpec, openapi3filter.Options{
 					AuthenticationFunc: auth.Middleware(
 						auth.WithKey(mgmtStores, auth.SurfaceClient),
@@ -118,9 +123,6 @@ func NewServer(ctx graceful.Context, logger *zap.Logger, cfg config.Node, db *st
 						auth.WithTrustedIssuer(mgmtStores, jwksCache),
 					),
 				}),
-				// Runs after the validator (and thus after authentication) so
-				// the limiter keys on the resolved auth method.
-				http.RateLimit(limiter, cfg.RateLimit.PerMinute, time.Minute, cfg.RateLimit.TrustedProxyHops, clientoapi.WriteProblem),
 			},
 		})
 	})

--- a/internal/http/ratelimit_test.go
+++ b/internal/http/ratelimit_test.go
@@ -127,6 +127,73 @@ func TestRateLimitFailsOpenOnBackendError(t *testing.T) {
 	require.Empty(t, rec.Header().Get("Retry-After"))
 }
 
+// authSetter mimics the validator's AuthenticationFunc: it resolves an actor
+// (here from a test header) and puts it on the request context for the inner
+// chain, exactly as auth.Middleware does via an in-place request mutation.
+func authSetter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id := r.Header.Get("X-Test-Actor"); id != "" {
+			actor := rbac.NewActor(rbac.ActorAPIKey, id)
+			r = r.WithContext(rbac.WithActor(r.Context(), actor))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// TestRateLimitRunsAfterAuth guards the middleware ordering. The generated oapi
+// wrapper composes middlewares with a forward-wrapping loop
+// (handler = mw(handler)), so the LAST slice entry runs FIRST. RateLimit must
+// therefore be listed before the validator so it runs *after* authentication
+// and keys on the resolved actor. If the order regresses, the limiter runs
+// before auth, every request falls back to the shared ip: bucket, and two
+// distinct keys from the same IP starve a single budget.
+func TestRateLimitRunsAfterAuth(t *testing.T) {
+	t.Parallel()
+
+	limiter := newRedisLimiter(t)
+	rl := RateLimit(limiter, 1, time.Minute, 0, oapi.WriteProblem)
+
+	var reached int
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Compose exactly like the generated HandlerWithOptions wrapper: the slice
+	// is ordered [RateLimit, validator] and applied front-to-back, making the
+	// validator (authSetter) the outermost so it runs first.
+	middlewares := []func(http.Handler) http.Handler{rl, authSetter}
+	handler := http.Handler(final)
+	for _, mw := range middlewares {
+		handler = mw(handler)
+	}
+
+	// All requests share one RemoteAddr, so a buggy (pre-auth) limiter would
+	// key them all to a single ip: bucket.
+	newReq := func(actor string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/api/client/v1/events", nil)
+		r.RemoteAddr = "198.51.100.30:6666"
+		r.Header.Set("X-Test-Actor", actor)
+		return r
+	}
+
+	do := func(actor string) int {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newReq(actor))
+		return rec.Code
+	}
+
+	// Actor A spends its budget of one, then is denied on the second request.
+	require.Equal(t, http.StatusOK, do("ak_A"))
+	require.Equal(t, http.StatusTooManyRequests, do("ak_A"))
+
+	// Actor B shares the same IP but must have its own budget — this only holds
+	// if the limiter keyed on the actor, i.e. it ran after auth.
+	require.Equal(t, http.StatusOK, do("ak_B"))
+
+	require.Equal(t, 2, reached, "only the two allowed requests reach the handler")
+}
+
 func TestRateLimitKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The rate limiter runs **before** authentication, so every request is keyed on the client IP instead of the authenticated auth method. Behind a reverse proxy / ingress that IP is the proxy's — identical for all traffic — which collapses the entire deployment into a single shared 600/min bucket. In practice, API-key event ingestion and Clerk-authenticated console sessions starve each other's budget and return spurious 429s.

## Root cause

The generated oapi `HandlerWithOptions` wrapper composes middlewares with a forward-wrapping loop:

```go
for _, middleware := range siw.HandlerMiddlewares {
    handler = middleware(handler)
}
```

This makes the **last** entry in the `Middlewares` slice the **outermost** wrapper, so it executes **first**. The slice was ordered `[Validator, RateLimit]`, so `RateLimit` actually ran *before* the validator's `AuthenticationFunc`. At that point `rbac.FromContext` is always `nil`, so `rateLimitKey` falls through to the `ip:` branch on every request.

With `TrustedProxyHops` defaulting to `0`, the IP used is `RemoteAddr` (the direct peer = the proxy), so all authenticated traffic shares one `ip:<proxyIP>` bucket. The previous in-code comments ("Runs after the validator …") described the *intended* order, but the generated wrapper reverses it.

## Fix

List `RateLimit` **before** the validator on both the management and client surfaces, so it becomes the inner wrapper and runs *after* authentication — keying on the resolved actor as intended (`key:<authMethodID>` for API keys, `key:<authMethodID>:<subject>` for session / trusted-issuer end users). Comments updated to explain the reversed wrapping order.

## Test

Adds `TestRateLimitRunsAfterAuth`, which composes the chain exactly like the generated wrapper and asserts that two actors sharing one `RemoteAddr` get **independent** budgets — which only holds if the limiter runs after auth. Verified this test fails (200 expected, got 429) under the old ordering.

`go build ./...` passes; all `TestRateLimit*` tests pass.

## Note / follow-up

When `RateLimit` runs inner of the validator, unauthenticated requests are rejected by the validator (401) before reaching the limiter, so the `ip:` fallback no longer throttles unauthenticated traffic. If IP-based throttling of unauthenticated/abusive traffic is also desired, that's a separate two-tier setup (outer IP limiter + inner actor limiter) and out of scope for this fix.