### PR TITLE
fix(console): show schedule name instead of ID after creation

### DIFF
--- a/console/src/components/scheduled-detail-table.tsx
+++ b/console/src/components/scheduled-detail-table.tsx
@@ -230,7 +230,7 @@ export default function ScheduledDetailTable({
     }
 
     // Fetch scheduled schemas to get id→name mapping
-    const [schemasResult] = useResolver(
+    const [schemasResult, , reloadSchemas] = useResolver(
         useCallback(async () => {
             try {
                 const { data } = await client.get<{ results: ScheduledSchema[] }>(
@@ -312,7 +312,10 @@ export default function ScheduledDetailTable({
                 )
             }
 
-            await reloadScheduled()
+            // Creating with a new name registers a new schedule schema, so refresh
+            // the id→name map too — otherwise the new row falls back to showing its
+            // raw scheduled_id (a UUID) instead of the name the user just entered.
+            await Promise.all([reloadScheduled(), reloadSchemas()])
             setIsCreateOpen(false)
             scheduledForm.reset()
             setNewScheduledData({})


### PR DESCRIPTION
## Problem

When creating a schedule on a user/organization detail page in the console, the newly created row showed the schedule's **ID (a UUID)** instead of the **name** the user just entered.

## Root cause

`scheduled-detail-table.tsx` displays each row's name by resolving its `scheduled_id` through a `schemaMap` (id → name) built from `/scheduled/schema`. That schema list is fetched **once on mount** and never refreshed.

Creating a schedule with a brand-new name registers a **new schema row** (new id) server-side. After create, only the instance list was reloaded (`reloadScheduled()`) — not the schema list — so `schemaMap` had no entry for the new `scheduled_id`, and the row fell back to rendering the raw UUID:

```ts
const name = schemaMap.get(item.scheduled_id) ?? item.scheduled_id // ← UUID fallback
```

## Fix

Capture the schema resolver's reload function and refresh it alongside the instance list after a successful create:

```ts
const [schemasResult, , reloadSchemas] = useResolver(/* … */)
// …
await Promise.all([reloadScheduled(), reloadSchemas()])
```

The new id→name mapping is now available immediately, so the row shows the entered name.

## Scope check

I swept the other entity-creation flows (campaigns, journeys, lists, users, organizations, broadcasts) for the same `name = id` anti-pattern. None reproduce it — they all reload from the server and render server-provided `name` fields (the `?? .id` occurrences elsewhere are only color-hash seeds or legitimate identity fallbacks). The bug is isolated to the scheduled table, which is the only place that resolves a display name through a separately-cached map.

## Testing

- `tsc --noEmit` passes clean.